### PR TITLE
Fix few typos in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,11 +36,11 @@ with open('test-requirements.txt') as f:
 setup(
     name=PACKAGE_NAME,
     version=CLIENT_VERSION,
-    description="Kubernetes python client",
+    description="Kubernetes asynchronous python client",
     author_email="",
     author="Kubernetes",
     license="Apache License Version 2.0",
-    url="https://github.com/kubernetes-client/python",
+    url="https://github.com/tomplus/kubernetes_asyncio",
     keywords=[
         "Swagger",
         "OpenAPI",


### PR DESCRIPTION
Hi folks!

After poking around this lib in Pypi.org, I found out that "homepage" link leads to `Kubernetes python client` gh page. This PR fixes that issue.

Changes:
- supplemented module description with "asynchronous" keyword
- make url lead to right repo

Take care
Patryk