### PR TITLE
Stop the iterator for empty responses and do not process ERROR responses

### DIFF
--- a/kubernetes_asyncio/watch/watch.py
+++ b/kubernetes_asyncio/watch/watch.py
@@ -60,7 +60,6 @@ class Watch(object):
         self._raw_return_type = return_type
         self._stop = False
         self._api_client = client.ApiClient()
-        self.resource_version = 0
 
     def stop(self):
         self._stop = True
@@ -69,6 +68,7 @@ class Watch(object):
         if self._raw_return_type:
             return self._raw_return_type
         return_type = _find_return_type(func)
+
         if return_type.endswith(TYPE_LIST_SUFFIX):
             return return_type[:-len(TYPE_LIST_SUFFIX)]
         return return_type
@@ -79,8 +79,7 @@ class Watch(object):
         if return_type:
             obj = SimpleNamespace(data=json.dumps(js['raw_object']))
             js['object'] = self._api_client.deserialize(obj, return_type)
-            if hasattr(js['object'], 'metadata'):
-                self.resource_version = js['object'].metadata.resource_version
+
         return js
 
     def __aiter__(self):
@@ -129,7 +128,6 @@ class Watch(object):
         self.return_type = self.get_return_type(func)
         kwargs['watch'] = True
         kwargs['_preload_content'] = False
-        timeouts = ('timeout_seconds' in kwargs)
 
         self.func = partial(func, *args, **kwargs)
         self.resp = None

--- a/kubernetes_asyncio/watch/watch.py
+++ b/kubernetes_asyncio/watch/watch.py
@@ -14,9 +14,9 @@
 
 import json
 import pydoc
-
 from functools import partial
 from types import SimpleNamespace
+
 from kubernetes_asyncio import client
 
 PYDOC_RETURN_LABEL = ":return:"

--- a/kubernetes_asyncio/watch/watch_test.py
+++ b/kubernetes_asyncio/watch/watch_test.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from asynctest import CoroutineMock, Mock, TestCase, patch
+from asynctest import CoroutineMock, Mock, TestCase
 
 import json
 import kubernetes_asyncio

--- a/kubernetes_asyncio/watch/watch_test.py
+++ b/kubernetes_asyncio/watch/watch_test.py
@@ -51,7 +51,8 @@ class WatchTest(TestCase):
                 watch.stop()
 
         fake_api.get_namespaces.assert_called_once_with(
-            _preload_content=False, watch=True)
+            _preload_content=False, watch=True, resource_version='123')
+
     async def test_watch_k8s_empty_response(self):
         """Stop the iterator when the response is empty.
 

--- a/kubernetes_asyncio/watch/watch_test.py
+++ b/kubernetes_asyncio/watch/watch_test.py
@@ -86,7 +86,7 @@ class WatchTest(TestCase):
         cnt = 0
         async for _ in watch.stream(fake_api.get_namespaces):
             cnt += 1
-        assert cnt == len(side_effects)
+        self.assertEqual(cnt, len(side_effects))
 
     def test_unmarshal_with_float_object(self):
         w = Watch()
@@ -123,8 +123,9 @@ class WatchTest(TestCase):
         }
 
         ret = Watch().unmarshal_event(json.dumps(k8s_err), None)
-        assert ret['type'] == k8s_err['type']
-        assert ret['object'] == ret['raw_object'] == k8s_err['object']
+        self.assertEqual(ret['type'], k8s_err['type'])
+        self.assertEqual(ret['object'], k8s_err['object'])
+        self.assertEqual(ret['object'], k8s_err['object'])
 
     async def test_watch_with_exception(self):
         fake_resp = CoroutineMock()


### PR DESCRIPTION
This PR solves two problems I encountered:

* Raise `StopIteration` for empty K8s responses (eg when the timeout expires).
* Do not process K8s error responses but pass them verbatim to the user instead.