### PR TITLE
fix: handling timeout by watch loop

### DIFF
--- a/kubernetes_asyncio/watch/watch.py
+++ b/kubernetes_asyncio/watch/watch.py
@@ -128,6 +128,7 @@ class Watch(object):
                 line = await self.resp.content.readline()
             except asyncio.TimeoutError:
                 if 'timeout_seconds' not in self.func.keywords:
+                    self.resp.close()
                     self.resp = None
                     self.func.keywords['resource_version'] = self.resource_version
                     continue


### PR DESCRIPTION
resolve #29 

Not closed connections filled up a connection pool and new connections couldn't be created.
