### PR TITLE
fix: trailing slash on kube/config

### DIFF
--- a/kubernetes_asyncio/config/kube_config.py
+++ b/kubernetes_asyncio/config/kube_config.py
@@ -326,7 +326,7 @@ class KubeConfigLoader(object):
 
     def _load_cluster_info(self):
         if 'server' in self._cluster:
-            self.host = self._cluster['server']
+            self.host = self._cluster['server'].rstrip('/')
             if self.host.startswith("https"):
                 self.ssl_ca_cert = FileOrData(
                     self._cluster, 'certificate-authority',


### PR DESCRIPTION
It's ported from https://github.com/kubernetes-client/python-base/pull/45