### PR TITLE
feat: remove dependency to urllib3 from kube_config, pin urlllib>=1.23 due to CVE-2018-20060

### DIFF
--- a/kubernetes_asyncio/config/kube_config.py
+++ b/kubernetes_asyncio/config/kube_config.py
@@ -21,7 +21,6 @@ import logging
 import os
 import tempfile
 
-import urllib3
 import yaml
 
 from kubernetes_asyncio.client import ApiClient, Configuration
@@ -319,9 +318,9 @@ class KubeConfigLoader(object):
 
     def _load_user_pass_token(self):
         if 'username' in self._user and 'password' in self._user:
-            self.token = urllib3.util.make_headers(
-                basic_auth=(self._user['username'] + ':' +
-                            self._user['password'])).get('authorization')
+            basic_auth = self._user['username'] + ':' + self._user['password']
+            self.token = 'Basic ' + base64.b64encode(
+                basic_auth.encode()).decode('utf-8')
             return True
 
     def _load_cluster_info(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ certifi>=14.05.14 # MPL
 six>=1.9.0  # MIT
 python-dateutil>=2.5.3  # BSD
 setuptools>=21.0.0  # PSF/ZPL
-urllib3>=1.19.1,!=1.21,<1.23  # MIT
+urllib3>=1.23  # MIT
 pyyaml>=3.12  # MIT
 aiohttp>=2.3.10 # # Apache-2.0


### PR DESCRIPTION
This library doesn't need to use the urllib3 - it uses the iohttp instead. In this PR I remove a dependency to urllib3 from kube_config.py. The library is still required by the generated part by swagger-codegen.

I also change the required version >=1.23 due to security patches.