### PR TITLE
fix #60

### DIFF
--- a/examples/example2.py
+++ b/examples/example2.py
@@ -11,14 +11,18 @@ async def main():
 
     v1 = client.CoreV1Api()
     count = 10
-    async with watch.Watch() as w:
-        async for event in w.stream(v1.list_namespace, timeout_seconds=10):
-            print("Event: {} {}".format(event['type'], event['object'].metadata.name))
-            count -= 1
-            if not count:
-                w.stop()
+    w = watch.Watch()
+
+    async for event in w.stream(v1.list_namespace, timeout_seconds=10):
+        print("Event: {} {}".format(event['type'], event['object'].metadata.name))
+        count -= 1
+        if not count:
+            w.stop()
 
     print("Ended.")
+    # An explicit close is necessary to stop the stream
+    # or use async context manager like in example4.py
+    w.close()
 
 
 if __name__ == '__main__':

--- a/examples/example2.py
+++ b/examples/example2.py
@@ -11,13 +11,12 @@ async def main():
 
     v1 = client.CoreV1Api()
     count = 10
-    w = watch.Watch()
-
-    async for event in w.stream(v1.list_namespace, timeout_seconds=10):
-        print("Event: {} {}".format(event['type'], event['object'].metadata.name))
-        count -= 1
-        if not count:
-            w.stop()
+    async with watch.Watch() as w:
+        async for event in w.stream(v1.list_namespace, timeout_seconds=10):
+            print("Event: {} {}".format(event['type'], event['object'].metadata.name))
+            count -= 1
+            if not count:
+                w.stop()
 
     print("Ended.")
 

--- a/examples/example4.py
+++ b/examples/example4.py
@@ -6,16 +6,18 @@ from kubernetes_asyncio import client, config, watch
 
 async def watch_namespaces():
     v1 = client.CoreV1Api()
-    async for event in watch.Watch().stream(v1.list_namespace):
-        etype, obj = event['type'], event['object']
-        print("{} namespace {}".format(etype, obj.metadata.name))
+    async with watch.Watch().stream(v1.list_namespace) as stream:
+        async for event in stream:
+            etype, obj = event['type'], event['object']
+            print("{} namespace {}".format(etype, obj.metadata.name))
 
 
 async def watch_pods():
     v1 = client.CoreV1Api()
-    async for event in watch.Watch().stream(v1.list_pod_for_all_namespaces):
-        evt, obj = event['type'], event['object']
-        print("{} pod {} in NS {}".format(evt, obj.metadata.name, obj.metadata.namespace))
+    async with watch.Watch().stream(v1.list_pod_for_all_namespaces) as stream:
+        async for event in stream:
+            evt, obj = event['type'], event['object']
+            print("{} pod {} in NS {}".format(evt, obj.metadata.name, obj.metadata.namespace))
 
 
 def main():

--- a/kubernetes_asyncio/watch/watch.py
+++ b/kubernetes_asyncio/watch/watch.py
@@ -179,7 +179,6 @@ class Watch(object):
         kwargs['_preload_content'] = False
 
         self.func = partial(func, *args, **kwargs)
-        self.resp = None
 
         return self
 

--- a/kubernetes_asyncio/watch/watch.py
+++ b/kubernetes_asyncio/watch/watch.py
@@ -111,10 +111,7 @@ class Watch(object):
         try:
             return await self.next()
         except:
-            if self.resp is not None:
-                # clean up
-                self.resp.release()
-                self.resp = None
+            self.close()
             raise
 
     async def next(self):
@@ -177,9 +174,7 @@ class Watch(object):
                 if should_stop:
                     watch.stop()
         """
-        if self.resp is not None:
-            self.resp.release()
-            self.resp = None
+        self.close()
         self._stop = False
         self.return_type = self.get_return_type(func)
         kwargs['watch'] = True
@@ -193,6 +188,9 @@ class Watch(object):
         return self
 
     async def __aexit__(self, exc_type, exc_value, traceback):
-        if self.resp:
+        self.close()
+    
+    def close(self):
+        if self.resp is not None:
             self.resp.release()
             self.resp = None

--- a/kubernetes_asyncio/watch/watch.py
+++ b/kubernetes_asyncio/watch/watch.py
@@ -108,7 +108,14 @@ class Watch(object):
         return self
 
     async def __anext__(self):
-        return await self.next()
+        try:
+            return await self.next()
+        except:
+            if self.resp is not None:
+                # clean up
+                self.resp.release()
+                self.resp = None
+            raise
 
     async def next(self):
 

--- a/kubernetes_asyncio/watch/watch.py
+++ b/kubernetes_asyncio/watch/watch.py
@@ -186,7 +186,7 @@ class Watch(object):
     async def __aenter__(self):
         return self
 
-    async def __aexit__(self):
+    async def __aexit__(self, exc_type, exc_value, traceback):
         if self.resp:
             self.resp.release()
             self.resp = None

--- a/kubernetes_asyncio/watch/watch.py
+++ b/kubernetes_asyncio/watch/watch.py
@@ -50,6 +50,7 @@ class Watch(object):
         self._stop = False
         self._api_client = client.ApiClient()
         self.resource_version = 0
+        self.resp = None
 
     def stop(self):
         self._stop = True
@@ -169,6 +170,9 @@ class Watch(object):
                 if should_stop:
                     watch.stop()
         """
+        if self.resp is not None:
+            self.resp.release()
+            self.resp = None
         self._stop = False
         self.return_type = self.get_return_type(func)
         kwargs['watch'] = True
@@ -178,3 +182,11 @@ class Watch(object):
         self.resp = None
 
         return self
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self):
+        if self.resp:
+            self.resp.release()
+            self.resp = None

--- a/kubernetes_asyncio/watch/watch_test.py
+++ b/kubernetes_asyncio/watch/watch_test.py
@@ -26,6 +26,7 @@ class WatchTest(TestCase):
     async def test_watch_with_decode(self):
         fake_resp = CoroutineMock()
         fake_resp.content.readline = CoroutineMock()
+        fake_resp.release = Mock()
         side_effects = [
             {
                 "type": "ADDED",
@@ -64,6 +65,7 @@ class WatchTest(TestCase):
 
         fake_api.get_namespaces.assert_called_once_with(
             _preload_content=False, watch=True, resource_version='123')
+        fake_resp.release.assert_called_once_with()
 
     async def test_watch_k8s_empty_response(self):
         """Stop the iterator when the response is empty.
@@ -162,6 +164,7 @@ class WatchTest(TestCase):
     async def test_watch_timeout(self):
         fake_resp = CoroutineMock()
         fake_resp.content.readline = CoroutineMock()
+        fake_resp.release = Mock()
 
         mock_event = {"type": "ADDED",
                       "object": {"metadata": {"name": "test1555",
@@ -185,7 +188,7 @@ class WatchTest(TestCase):
         fake_api.get_namespaces.assert_has_calls(
             [call(_preload_content=False, watch=True),
              call(_preload_content=False, watch=True, resource_version='1555')])
-
+        fake_resp.release.assert_called_once_with()
 
 if __name__ == '__main__':
     import asynctest


### PR DESCRIPTION
This PR adds async context manager support on `Watch` object, so the response is correctly closed when watch is stopped with `stop()` or by some exceptions.

fix #60 