### PR TITLE
Check whether an object key is present on watch

### DIFF
--- a/kubernetes_asyncio/watch/watch.py
+++ b/kubernetes_asyncio/watch/watch.py
@@ -70,6 +70,8 @@ class Watch(object):
         """
         js = json.loads(data)
 
+        if 'object' not in js:
+            raise Exception(f"Malformed JSON response, 'object' field is missing. Response: {response_type}, JSON: {js}")
         # Make a copy of the original object and save it under the
         # `raw_object` key because we will replace the data under `object` with
         # a Python native type shortly.

--- a/kubernetes_asyncio/watch/watch.py
+++ b/kubernetes_asyncio/watch/watch.py
@@ -70,8 +70,8 @@ class Watch(object):
         """
         js = json.loads(data)
 
-        if 'object' not in js:
-            raise Exception("Malformed JSON response, 'object' field is missing. JSON: {}".format(js))
+        if 'object' not in js or 'type' not in js:
+            raise Exception("Malformed JSON response, the 'object' and/or 'type' field is missing. JSON: {}".format(js))
         # Make a copy of the original object and save it under the
         # `raw_object` key because we will replace the data under `object` with
         # a Python native type shortly.

--- a/kubernetes_asyncio/watch/watch.py
+++ b/kubernetes_asyncio/watch/watch.py
@@ -71,7 +71,7 @@ class Watch(object):
         js = json.loads(data)
 
         if 'object' not in js:
-            raise Exception(f"Malformed JSON response, 'object' field is missing. Response: {response_type}, JSON: {js}")
+            raise Exception("Malformed JSON response, 'object' field is missing. JSON: {}".format(js))
         # Make a copy of the original object and save it under the
         # `raw_object` key because we will replace the data under `object` with
         # a Python native type shortly.


### PR DESCRIPTION
The 'object' key may not be present in the case of unauthorized access (403) which leads to a KeyError that do not provide any information on the real error.

With this check, a sound error message with the message content is shown.