### PR TITLE
chore: remove deprecated option "sudo" from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 # ref: https://docs.travis-ci.com/user/languages/python
 language: python
 dist: xenial
-sudo: true
 services:
   - docker
 


### PR DESCRIPTION
Porting https://github.com/kubernetes-client/python/pull/896 from the official client.