### PR TITLE
fix: watch.stream stores resource_version for the next call

### DIFF
--- a/kubernetes_asyncio/watch/watch.py
+++ b/kubernetes_asyncio/watch/watch.py
@@ -181,6 +181,8 @@ class Watch(object):
         self.return_type = self.get_return_type(func)
         kwargs['watch'] = True
         kwargs['_preload_content'] = False
+        if 'resource_version' in kwargs:
+            self.resource_version = kwargs['resource_version']
 
         self.func = partial(func, *args, **kwargs)
 


### PR DESCRIPTION
The method Watch.Stream stores a resource version to use in the next calls if the first hasn't returned another value. 

Fixes #77