### PR TITLE
fix: install conntrack required by minikube

### DIFF
--- a/scripts/kube-init.sh
+++ b/scripts/kube-init.sh
@@ -34,6 +34,7 @@ setenforce 0
 HOME=/home/travis
 
 # Install conntrack (required by minikube)
+sudo apt-get update
 sudo apt-get install -y conntrack
 
 # Install docker if needed

--- a/scripts/kube-init.sh
+++ b/scripts/kube-init.sh
@@ -33,6 +33,9 @@ setenforce 0
 # define HOME dir
 HOME=/home/travis
 
+# Install conntrack (required by minikube)
+sudo apt-get install -y conntrack
+
 # Install docker if needed
 path_to_executable=$(which docker)
 if [ -x "$path_to_executable" ] ; then


### PR DESCRIPTION
The latest version of minikube/k8s requires conntrack and e2e tests fail with the error:

`The none driver requires conntrack to be installed for kubernetes version 1.18.0`.

Ref: https://github.com/kubernetes/minikube/issues/7179