### PR TITLE
chore: CI works with the latest isort

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -42,7 +42,7 @@ jobs:
       if: matrix.python-version == 3.8
       run: |
         flake8
-        isort -c --diff
+        isort -c --diff .
 
     - name: Send coverage report
       if: matrix.python-version == 3.8

--- a/kubernetes_asyncio/config/__init__.py
+++ b/kubernetes_asyncio/config/__init__.py
@@ -14,5 +14,7 @@
 
 from .config_exception import ConfigException
 from .incluster_config import load_incluster_config
-from .kube_config import (list_kube_config_contexts, load_kube_config,
-                          new_client_from_config, refresh_token)
+from .kube_config import (
+    list_kube_config_contexts, load_kube_config, new_client_from_config,
+    refresh_token,
+)

--- a/kubernetes_asyncio/config/incluster_config_test.py
+++ b/kubernetes_asyncio/config/incluster_config_test.py
@@ -17,8 +17,10 @@ import tempfile
 import unittest
 
 from .config_exception import ConfigException
-from .incluster_config import (SERVICE_HOST_ENV_NAME, SERVICE_PORT_ENV_NAME,
-                               InClusterConfigLoader, _join_host_port)
+from .incluster_config import (
+    SERVICE_HOST_ENV_NAME, SERVICE_PORT_ENV_NAME, InClusterConfigLoader,
+    _join_host_port,
+)
 
 _TEST_TOKEN = "temp_token"
 _TEST_CERT = "temp_cert"

--- a/kubernetes_asyncio/config/kube_config_test.py
+++ b/kubernetes_asyncio/config/kube_config_test.py
@@ -24,11 +24,12 @@ from asynctest import Mock, TestCase, main, patch
 from six import PY3
 
 from .config_exception import ConfigException
-from .kube_config import (ENV_KUBECONFIG_PATH_SEPARATOR, ConfigNode,
-                          FileOrData, KubeConfigLoader, KubeConfigMerger,
-                          _cleanup_temp_files, _create_temp_file_with_content,
-                          list_kube_config_contexts, load_kube_config,
-                          new_client_from_config, refresh_token)
+from .kube_config import (
+    ENV_KUBECONFIG_PATH_SEPARATOR, ConfigNode, FileOrData, KubeConfigLoader,
+    KubeConfigMerger, _cleanup_temp_files, _create_temp_file_with_content,
+    list_kube_config_contexts, load_kube_config, new_client_from_config,
+    refresh_token,
+)
 
 BEARER_TOKEN_FORMAT = "Bearer %s"
 

--- a/kubernetes_asyncio/config/openid_test.py
+++ b/kubernetes_asyncio/config/openid_test.py
@@ -3,8 +3,9 @@ import json
 from contextlib import contextmanager
 
 from aiohttp import web
-from aiohttp.test_utils import TestClient as _TestClient
-from aiohttp.test_utils import TestServer as _TestServer
+from aiohttp.test_utils import (
+    TestClient as _TestClient, TestServer as _TestServer,
+)
 from asynctest import TestCase, patch
 
 from .config_exception import ConfigException


### PR DESCRIPTION
The latest version of isort requires start path to search files and also this version has found some unordered imports too.