### PR TITLE
fix: remove redundant close() in Watch class

### DIFF
--- a/kubernetes_asyncio/watch/watch.py
+++ b/kubernetes_asyncio/watch/watch.py
@@ -187,7 +187,6 @@ class Watch(object):
                 if should_stop:
                     watch.stop()
         """
-        self.close()
         self._stop = False
         self.return_type = self.get_return_type(func)
         kwargs[self.get_watch_argument_name(func)] = True


### PR DESCRIPTION
It fixes https://github.com/tomplus/kubernetes_asyncio/issues/109.