### PR TITLE
fix: remove checking headers if raw content is returned from rest api

### DIFF
--- a/kubernetes_asyncio/client/api_client.py
+++ b/kubernetes_asyncio/client/api_client.py
@@ -188,10 +188,7 @@ class ApiClient(object):
             e.body = e.body.decode('utf-8') if six.PY3 else e.body
             raise e
 
-        content_type = response_data.getheader('content-type')
-
         self.last_response = response_data
-
         return_data = response_data
 
         if not _preload_content:
@@ -199,6 +196,7 @@ class ApiClient(object):
 
         if six.PY3 and response_type not in ["file", "bytes"]:
             match = None
+            content_type = response_data.getheader('content-type')
             if content_type is not None:
                 match = re.search(r"charset=([a-zA-Z\-\d]+)[\s\;]?", content_type)
             encoding = match.group(1) if match else "utf-8"


### PR DESCRIPTION
It solves #122 

The workaround is implemented manually on generated code. PR for OpenApi generator is on the way.