### PR TITLE
fix: show warning if config not loaded

### DIFF
--- a/kubernetes_asyncio/config/kube_config.py
+++ b/kubernetes_asyncio/config/kube_config.py
@@ -398,7 +398,7 @@ class ConfigNode(object):
 
     def safe_get(self, key):
         if (isinstance(self.value, list) and isinstance(key, int) or
-                key in self.value):
+                (self.value and key in self.value)):
             return self.value[key]
 
     def __getitem__(self, key):
@@ -461,13 +461,17 @@ class KubeConfigMerger:
         self.config_files = {}
         self.config_merged = None
 
+        file_loaded = False
         for path in paths.split(ENV_KUBECONFIG_PATH_SEPARATOR):
             if path:
                 path = os.path.expanduser(path)
                 if os.path.exists(path):
                     self.paths.append(path)
                     self.load_config(path)
+                    file_loaded = True
         self.config_saved = copy.deepcopy(self.config_files)
+        if not file_loaded:
+            logging.warning('Config not found: %s', paths)
 
     @property
     def config(self):


### PR DESCRIPTION
There is a bug to access the current context in configuration file when no configuration is loaded.
I've also added an extra warning if none of configuration files exist.

It fixes #126 