### PR TITLE
tests: e2e tests ignore system config-maps.

### DIFF
--- a/kubernetes_asyncio/e2e_test/test_client.py
+++ b/kubernetes_asyncio/e2e_test/test_client.py
@@ -216,7 +216,8 @@ class TestClient(asynctest.TestCase):
             name=name, body={}, namespace='default')
 
         resp = await api.list_namespaced_config_map('default', pretty=True)
-        self.assertEqual([], resp.items)
+        for item in resp.items:
+            self.assertNotEqual(item.metadata.name, name)
 
     async def test_node_apis(self):
         client = api_client.ApiClient(configuration=self.config)


### PR DESCRIPTION
The latest version of minikube adds a ConfigMap to the 'default' namespace, so e2e tests for deleting operation have to more precise. 