### PR TITLE
Increase aiohttp read buffer to 2MiB

### DIFF
--- a/kubernetes_asyncio/client/rest.py
+++ b/kubernetes_asyncio/client/rest.py
@@ -78,7 +78,14 @@ class RESTClientObject(object):
 
         # https pool manager
         self.pool_manager = aiohttp.ClientSession(
-            connector=connector
+            connector=connector,
+            # Watch events containing large resource objects can exceed
+            # aiohttp's default read buffer size.
+            #
+            # There is no hard-limit defined by k8s, but the etcd default
+            # maximum request size is 1.5MiB.
+            # https://github.com/kubernetes/kubernetes/issues/19781
+            read_bufsize=2**21
         )
 
     async def close(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ python-dateutil>=2.5.3  # BSD
 setuptools>=21.0.0  # PSF/ZPL
 urllib3>=1.24.2  # MIT
 pyyaml>=3.12  # MIT
-aiohttp>=2.3.10,<4.0.0 # # Apache-2.0
+aiohttp>=3.7.0,<4.0.0 # # Apache-2.0


### PR DESCRIPTION
The previous default (64KiB) would cause `ValueError: Line is too long`
exceptions on watch events with large objects.

Requires aiohttp >= 3.7.0