### PR TITLE
fix: watch returns raw_object if detection of returned objects fail

### DIFF
--- a/kubernetes_asyncio/watch/watch.py
+++ b/kubernetes_asyncio/watch/watch.py
@@ -104,7 +104,7 @@ class Watch(object):
 
         # If possible, compile the JSON response into a Python native response
         # type, eg `V1Namespace` or `V1Pod`,`ExtensionsV1beta1Deployment`, ...
-        if response_type is not None:
+        if response_type:
             js['object'] = self._api_client.deserialize(
                 response=SimpleNamespace(data=json.dumps(js['raw_object'])),
                 response_type=response_type

--- a/kubernetes_asyncio/watch/watch_test.py
+++ b/kubernetes_asyncio/watch/watch_test.py
@@ -135,10 +135,20 @@ class WatchTest(TestCase):
         self.assertTrue(isinstance(event['object'], float))
         self.assertEqual(1, event['raw_object'])
 
-    def test_unmarshal_with_no_return_type(self):
+    def test_unmarshal_without_return_type(self):
         w = Watch()
         event = w.unmarshal_event(
             '{"type": "ADDED", "object": ["test1"]}', None)
+        self.assertEqual("ADDED", event['type'])
+        self.assertEqual(["test1"], event['object'])
+        self.assertEqual(["test1"], event['raw_object'])
+
+    def test_unmarshal_with_empty_return_type(self):
+        # empty string as a return_type is a default value
+        # if watch can't detect object by function's name
+        w = Watch()
+        event = w.unmarshal_event(
+            '{"type": "ADDED", "object": ["test1"]}', '')
         self.assertEqual("ADDED", event['type'])
         self.assertEqual(["test1"], event['object'])
         self.assertEqual(["test1"], event['raw_object'])


### PR DESCRIPTION
Closes #176 