### PR TITLE
[fix] passing Bearer token in authorization header

### DIFF
--- a/kubernetes_asyncio/config/incluster_config.py
+++ b/kubernetes_asyncio/config/incluster_config.py
@@ -80,7 +80,7 @@ class InClusterConfigLoader(object):
         configuration = Configuration()
         configuration.host = self.host
         configuration.ssl_ca_cert = self.ssl_ca_cert
-        configuration.api_key['authorization'] = "bearer " + self.token
+        configuration.api_key['BearerToken'] = "Bearer " + self.token
         Configuration.set_default(configuration)
 
 

--- a/kubernetes_asyncio/config/kube_config.py
+++ b/kubernetes_asyncio/config/kube_config.py
@@ -367,7 +367,7 @@ class KubeConfigLoader(object):
     def _set_config(self, client_configuration):
 
         if 'token' in self.__dict__:
-            client_configuration.api_key['authorization'] = self.token
+            client_configuration.api_key['BearerToken'] = self.token
 
         # copy these keys directly from self to configuration object
         keys = ['host', 'ssl_ca_cert', 'cert_file', 'key_file', 'verify_ssl']
@@ -626,7 +626,7 @@ async def refresh_token(loader, client_configuration=None, interval=60):
     while 1:
         await asyncio.sleep(interval)
         await loader.load_gcp_token()
-        client_configuration.api_key['authorization'] = loader.token
+        client_configuration.api_key['BearerToken'] = loader.token
 
 
 async def new_client_from_config(config_file=None, context=None, persist_config=True,

--- a/kubernetes_asyncio/config/kube_config_test.py
+++ b/kubernetes_asyncio/config/kube_config_test.py
@@ -284,7 +284,7 @@ class FakeConfig:
     def __init__(self, token=None, **kwargs):
         self.api_key = {}
         if token:
-            self.api_key['authorization'] = token
+            self.api_key['BearerToken'] = token
 
         self.__dict__.update(kwargs)
 
@@ -735,7 +735,7 @@ class TestKubeConfigLoader(BaseTestCase):
             "token": token
         }
         expected = FakeConfig(host=TEST_HOST, api_key={
-                              "authorization": BEARER_TOKEN_FORMAT % token})
+                              "BearerToken": BEARER_TOKEN_FORMAT % token})
         actual = FakeConfig()
         await KubeConfigLoader(
             config_dict=self.TEST_KUBE_CONFIG,
@@ -904,14 +904,14 @@ class TestKubeConfigLoader(BaseTestCase):
             config_file=config_file, context="simple_token")
         self.assertEqual(TEST_HOST, client.configuration.host)
         self.assertEqual(BEARER_TOKEN_FORMAT % TEST_DATA_BASE64,
-                         client.configuration.api_key['authorization'])
+                         client.configuration.api_key['BearerToken'])
 
     async def test_new_client_from_config_dict(self):
         client = await new_client_from_config_dict(
             config_dict=self.TEST_KUBE_CONFIG, context="simple_token")
         self.assertEqual(TEST_HOST, client.configuration.host)
         self.assertEqual(BEARER_TOKEN_FORMAT % TEST_DATA_BASE64,
-                         client.configuration.api_key['authorization'])
+                         client.configuration.api_key['BearerToken'])
 
     async def test_no_users_section(self):
         expected = FakeConfig(host=TEST_HOST)
@@ -1091,7 +1091,7 @@ class TestKubeConfigMerger(BaseTestCase):
             config_file=kubeconfigs, context="simple_token")
         self.assertEqual(TEST_HOST, client.configuration.host)
         self.assertEqual(BEARER_TOKEN_FORMAT % TEST_DATA_BASE64,
-                         client.configuration.api_key['authorization'])
+                         client.configuration.api_key['BearerToken'])
 
     def test_save_changes(self):
         kubeconfigs = self._create_multi_config()


### PR DESCRIPTION
The latest version of OpenAPI Generator change/fix a field name to store authentication token (https://github.com/OpenAPITools/openapi-generator/pull/6469) and it causes authorization problem (#187, #188).