### PR TITLE
Configurable heartbeat value for WsApiClient

### DIFF
--- a/kubernetes_asyncio/stream/ws_client.py
+++ b/kubernetes_asyncio/stream/ws_client.py
@@ -49,6 +49,11 @@ class WsResponse(RESTResponse):
 
 class WsApiClient(ApiClient):
 
+    def __init__(self, configuration=None, header_name=None, header_value=None,
+                 cookie=None, pool_threads=1, heartbeat=None):
+        super().__init__(configuration, header_name, header_value, cookie, pool_threads)
+        self.heartbeat = heartbeat
+
     async def request(self, method, url, query_params=None, headers=None,
                       post_params=None, body=None, _preload_content=True,
                       _request_timeout=None):
@@ -77,7 +82,7 @@ class WsApiClient(ApiClient):
         if _preload_content:
 
             resp_all = ''
-            async with self.rest_client.pool_manager.ws_connect(url, headers=headers) as ws:
+            async with self.rest_client.pool_manager.ws_connect(url, headers=headers, heartbeat=self.heartbeat) as ws:
                 async for msg in ws:
                     msg = msg.data.decode('utf-8')
                     if len(msg) > 1:
@@ -91,4 +96,4 @@ class WsApiClient(ApiClient):
 
         else:
 
-            return await self.rest_client.pool_manager.ws_connect(url, headers=headers)
+            return await self.rest_client.pool_manager.ws_connect(url, headers=headers, heartbeat=self.heartbeat)

--- a/kubernetes_asyncio/stream/ws_client_test.py
+++ b/kubernetes_asyncio/stream/ws_client_test.py
@@ -19,6 +19,26 @@ from kubernetes_asyncio.stream import WsApiClient
 from kubernetes_asyncio.stream.ws_client import WsResponse, get_websocket_url
 
 
+class WsMock:
+    def __init__(self):
+        self.iter = 0
+
+    def __aiter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return self
+
+    async def __aenter__(self):
+        return self
+
+    async def __anext__(self):
+        self.iter += 1
+        if self.iter > 5:
+            raise StopAsyncIteration
+        return WsResponse(200, (chr(1) + 'mock').encode('utf-8'))
+
+
 class WSClientTest(TestCase):
 
     def test_websocket_client(self):
@@ -35,26 +55,6 @@ class WSClientTest(TestCase):
             self.assertEqual(get_websocket_url(url), ws_url)
 
     async def test_exec_ws(self):
-
-        class WsMock:
-            def __init__(self):
-                self.iter = 0
-
-            def __aiter__(self):
-                return self
-
-            async def __aexit__(self, exc_type, exc, tb):
-                return self
-
-            async def __aenter__(self):
-                return self
-
-            async def __anext__(self):
-                self.iter += 1
-                if self.iter > 5:
-                    raise StopAsyncIteration
-                return WsResponse(200, (chr(1) + 'mock').encode('utf-8'))
-
         mock = CoroutineMock()
         mock.RESTClientObject.return_value.pool_manager = mock
         mock.ws_connect.return_value = WsMock()
@@ -77,7 +77,35 @@ class WSClientTest(TestCase):
                     'sec-websocket-protocol': 'v4.channel.k8s.io',
                     'Accept': '*/*',
                     'User-Agent': api_client.user_agent
-                }
+                },
+                heartbeat=None
+            )
+
+    async def test_exec_ws_with_heartbeat(self):
+        mock = CoroutineMock()
+        mock.RESTClientObject.return_value.pool_manager = mock
+        mock.ws_connect.return_value = WsMock()
+        with patch('kubernetes_asyncio.client.api_client.rest', mock):
+
+            api_client = WsApiClient(heartbeat=30)
+            api_client.configuration.host = 'https://localhost'
+            ws = client.CoreV1Api(api_client=api_client)
+            resp = ws.connect_get_namespaced_pod_exec('pod', 'namespace',
+                                                      command='mock-command',
+                                                      stderr=True, stdin=False,
+                                                      stdout=True, tty=False)
+
+            ret = await resp
+            self.assertEqual(ret, 'mock' * 5)
+            mock.ws_connect.assert_called_once_with(
+                'wss://localhost/api/v1/namespaces/namespace/pods/pod/exec?'
+                'command=mock-command&stderr=True&stdin=False&stdout=True&tty=False',
+                headers={
+                    'sec-websocket-protocol': 'v4.channel.k8s.io',
+                    'Accept': '*/*',
+                    'User-Agent': api_client.user_agent
+                },
+                heartbeat=30
             )
 
 


### PR DESCRIPTION
Thir PR adds a configurable heartbeat value to the WsApiClient constructor, which defaults to None. This prevents connection timeouts when executing long commands with no outputs on remote pods.
A unit test has also been added to check that the heartbeat argument is correctly received in the constructor.

Fixes #193 