### PR TITLE
[chore] pin k8s version to 1.23.6 in e2e tests.

### DIFF
--- a/scripts/kube-init.sh
+++ b/scripts/kube-init.sh
@@ -47,7 +47,10 @@ fi
 docker --version
 
 # Get the latest stable version of kubernetes
-K8S_VERSION=$(curl -sS https://storage.googleapis.com/kubernetes-release/release/stable.txt)
+#K8S_VERSION=$(curl -sS https://storage.googleapis.com/kubernetes-release/release/stable.txt)
+# Problem with 1.24.0 in minikube, https://github.com/kubernetes/minikube/issues/14128
+# pin to previous version
+K8S_VERSION=1.23.6
 echo "K8S_VERSION : ${K8S_VERSION}"
 
 echo "Starting docker service"


### PR DESCRIPTION
E2E tests have not working since K8s 1.24.0 released.
It looks like some incompatibility problems are in minikube: https://github.com/kubernetes/minikube/issues/14128

