### PR TITLE
fixed watch.stream bug of not working with apis with follow kwarg

### DIFF
--- a/kubernetes_asyncio/watch/watch.py
+++ b/kubernetes_asyncio/watch/watch.py
@@ -21,7 +21,7 @@ from types import SimpleNamespace
 from kubernetes_asyncio import client
 
 PYDOC_RETURN_LABEL = ":rtype:"
-PYDOC_FOLLOW_PARAM = ":param bool follow:"
+PYDOC_FOLLOW_PARAM = ":param follow:"
 
 # Removing this suffix from return type name should give us event's object
 # type. e.g., if list_namespaces() returns "NamespaceList" type,

--- a/kubernetes_asyncio/watch/watch_test.py
+++ b/kubernetes_asyncio/watch/watch_test.py
@@ -81,7 +81,7 @@ class WatchTest(TestCase):
 
         fake_api = Mock()
         fake_api.read_namespaced_pod_log = CoroutineMock(return_value=fake_resp)
-        fake_api.read_namespaced_pod_log.__doc__ = ':param bool follow:\n:rtype: str'
+        fake_api.read_namespaced_pod_log.__doc__ = ':param follow:\n:type follow: bool\n:rtype: str'
 
         watch = kubernetes_asyncio.watch.Watch()
         count = 1


### PR DESCRIPTION
This PR should fix #215.

It still does not prevent the same issue from happening again. Not sure if there is a good way to prevent it.