### PR TITLE
Revert "[doc] use sphinx-autoapi"

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -2,6 +2,7 @@
 #
 
 # You can set these variables from the command line.
+SPHINXAPIDOC  = sphinx-apidoc
 SPHINXOPTS    = -c source
 SPHINXBUILD   = sphinx-build
 SPHINXPROJ    = kubernetes-client
@@ -16,7 +17,7 @@ help:
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
-
 html:
+	$(SPHINXAPIDOC) -o "$(SOURCEDIR)" ../kubernetes_asyncio/ -e -f
 	$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 	@echo "\nDocs rendered successfully, open _/build/html/index.html to view"

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -26,14 +26,10 @@ source_suffix = ['.rst']
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = [
-    'autoapi.extension',
     'sphinx.ext.autodoc',
     # 'myst_parser',
     # 'sphinx.ext.intersphinx',
 ]
-
-autoapi_type = 'python'
-autoapi_dirs = ['../../kubernetes_asyncio/']
 
 
 # autodoc generation is a bit aggressive and a nuisance when doing heavy

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -11,4 +11,3 @@ pytest-xdist
 randomize>=0.13
 recommonmark
 sphinx>=1.2.1,!=1.3b1,<6.2 # BSD
-sphinx-autoapi


### PR DESCRIPTION
Reverts tomplus/kubernetes_asyncio#242

This module is very slow and readthedocs.org build fails.