### PR TITLE
Proactor event loop on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,19 @@ like streaming, watching or reading configuration. Because of an early stage of 
 | authentication method | gcp-token, azure-token, user-token, oidc-token, user-password, in-cluster | gcp-token (only via gcloud command), user-token, oidc-token, user-password, in-cluster |
 | streaming data via websocket from PODs | bidirectional | read-only is already implemented |
 
+### Microsoft Windows
+In case this library is used against Kubernetes cluster using [client-go credentials plugin](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#client-go-credential-plugins), the default asyncio event loop is  [SelectorEventLoop](https://docs.python.org/3/library/asyncio-eventloop.html#event-loop-implementations). This event loop selector, however, does NOT support [pipes and subprocesses](https://bugs.python.org/issue37373), so `exec_provider.py::ExecProvider` is failing. In order to avoid failures the [ProactorEventLoop](https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.ProactorEventLoop) has to be selected. The ProactorEventLoop can be enabled via [WindowsProactorEventLoopPolicy](https://docs.python.org/3/library/asyncio-policy.html#asyncio.WindowsProactorEventLoopPolicy). 
+
+Application's code needs to contain followin code:
+
+```python
+import asyncio
+
+asyncio.set_event_loop_policy(
+    asyncio.WindowsProactorEventLoopPolicy()
+)
+```
+
 ## Versions
 
 This library is versioned in the same way as the synchronous library.

--- a/kubernetes_asyncio/config/exec_provider.py
+++ b/kubernetes_asyncio/config/exec_provider.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import asyncio
 import asyncio.subprocess
 import json
 import os
@@ -50,6 +51,11 @@ class ExecProvider(object):
             self.env.update(additional_vars)
 
     async def run(self, previous_response=None):
+        # Validate the run can be executed on Windows
+        if type(asyncio.get_event_loop()).__name__ == '_WindowsSelectorEventLoop':
+            raise ConfigException(
+                'exec: _WindowsSelectorEventLoop does NOT support subprocesses, see README.md')
+
         kubernetes_exec_info = {
             'apiVersion': self.api_version,
             'kind': 'ExecCredential',


### PR DESCRIPTION
This PR tends to resolve Windows compatibility issue I was facing the other day and tracked it under #246 . 

Eventually, I selected the documentation way since I believe a library should not be selecting any event policy on its own.