### PR TITLE
ci: test against python 3.11, and run codecov in a non-deprecated way

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -39,14 +39,13 @@ jobs:
         scripts/kube-init.sh py.test -vvv -s kubernetes_asyncio/e2e_test
 
     - name: Lint with flake8 and isort (only on the latest version of Python)
-      if: matrix.python-version == 3.10
+      if: matrix.python-version == '3.11'
       run: |
         flake8
         isort -c --diff .
 
     - name: Send coverage report
-      if: matrix.python-version == 3.10
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      run: |
-        codecov
+      uses: codecov/codecov-action@v3
+      if: matrix.python-version == '3.11'
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v3

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,4 @@
 asynctest
-codecov>=1.4.0
 flake8
 isort
 mock>=2.0.0


### PR DESCRIPTION
More about the deprecation of codecov uploader in https://github.com/codecov/codecov-action.