### PR TITLE
Remove deprecated packages asynctest, codecov

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,23 +32,22 @@ jobs:
 
     - name: Run unit tests
       run: |
-        py.test -vvv -s --ignore=kubernetes_asyncio/e2e_test --ignore=kubernetes_asyncio/test --cov-report=xml --cov=kubernetes_asyncio
         # splitted into 2 steps because of problem with event-loop in aiohttp
-        py.test -vvv -s --cov-report=xml --cov=kubernetes_asyncio kubernetes_asyncio/test
+        py.test -vvv -s --ignore=kubernetes_asyncio/e2e_test --ignore=kubernetes_asyncio/test --cov-report=xml --cov=kubernetes_asyncio
+        py.test -vvv -s --cov-report=xml --cov=kubernetes_asyncio2 kubernetes_asyncio/test --cov-append
 
     - name: Run e2e tests
       run: |
         scripts/kube-init.sh py.test -vvv -s kubernetes_asyncio/e2e_test
 
     - name: Lint with flake8 and isort (only on the latest version of Python)
-      if: matrix.python-version == 3.10
+      if: matrix.python-version == 3.11
       run: |
         flake8
         isort -c --diff .
 
     - name: Send coverage report
-      if: matrix.python-version == 3.10
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      run: |
-        codecov
+      uses: codecov/codecov-action@v3
+      if: matrix.python-version == 3.11
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v3
@@ -32,7 +32,9 @@ jobs:
 
     - name: Run unit tests
       run: |
-        py.test -vvv -s --ignore=kubernetes_asyncio/e2e_test --cov-report=xml --cov=kubernetes_asyncio
+        py.test -vvv -s --ignore=kubernetes_asyncio/e2e_test --ignore=kubernetes_asyncio/test --cov-report=xml --cov=kubernetes_asyncio
+        # splitted into 2 steps because of problem with event-loop in aiohttp
+        py.test -vvv -s --cov-report=xml --cov=kubernetes_asyncio kubernetes_asyncio/test
 
     - name: Run e2e tests
       run: |

--- a/README.md
+++ b/README.md
@@ -107,5 +107,5 @@ You can run the style checks and tests with
 ```bash
 flake8 kubernetes_asyncio/
 isort --diff kubernetes_asyncio/
-nosetests
+py.test
 ```

--- a/kubernetes_asyncio/config/exec_provider_test.py
+++ b/kubernetes_asyncio/config/exec_provider_test.py
@@ -15,14 +15,15 @@
 import json
 import sys
 
-from asynctest import ANY, TestCase, mock, patch
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import ANY, patch, AsyncMock
 
 from .config_exception import ConfigException
 from .exec_provider import ExecProvider
 from .kube_config import ConfigNode
 
 
-class ExecProviderTest(TestCase):
+class ExecProviderTest(IsolatedAsyncioTestCase):
 
     def setUp(self):
         self.input_ok = ConfigNode('test', {
@@ -44,9 +45,9 @@ class ExecProviderTest(TestCase):
         process_patch = patch('kubernetes_asyncio.config.exec_provider.asyncio.create_subprocess_exec')
         self.exec_mock = process_patch.start()
         self.process_mock = self.exec_mock.return_value
-        self.process_mock.stdout.read = mock.CoroutineMock(return_value=self.output_ok)
-        self.process_mock.stderr.read = mock.CoroutineMock(return_value='')
-        self.process_mock.wait = mock.CoroutineMock(return_value=0)
+        self.process_mock.stdout.read = AsyncMock(return_value=self.output_ok)
+        self.process_mock.stderr.read = AsyncMock(return_value='')
+        self.process_mock.wait = AsyncMock(return_value=0)
 
     def tearDown(self):
         patch.stopall()

--- a/kubernetes_asyncio/config/exec_provider_test.py
+++ b/kubernetes_asyncio/config/exec_provider_test.py
@@ -14,9 +14,8 @@
 
 import json
 import sys
-
 from unittest import IsolatedAsyncioTestCase
-from unittest.mock import ANY, patch, AsyncMock
+from unittest.mock import ANY, AsyncMock, patch
 
 from .config_exception import ConfigException
 from .exec_provider import ExecProvider

--- a/kubernetes_asyncio/config/google_auth_test.py
+++ b/kubernetes_asyncio/config/google_auth_test.py
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from asynctest import TestCase, main
+from unittest import IsolatedAsyncioTestCase
 
 from .google_auth import google_auth_credentials
 
 
-class TestGoogleAuth(TestCase):
+class TestGoogleAuth(IsolatedAsyncioTestCase):
 
     async def test_google_auth_credentials(self):
 
@@ -36,7 +36,3 @@ class TestGoogleAuth(TestCase):
 
         with self.assertRaisesRegex(ValueError, "cmd-path, cmd-args are required."):
             await google_auth_credentials({})
-
-
-if __name__ == '__main__':
-    main()

--- a/kubernetes_asyncio/config/kube_config_test.py
+++ b/kubernetes_asyncio/config/kube_config_test.py
@@ -20,7 +20,10 @@ import tempfile
 from types import SimpleNamespace
 
 import yaml
-from asynctest import Mock, TestCase, main, patch
+
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import patch, Mock
+
 from six import PY3
 
 from .config_exception import ConfigException
@@ -87,7 +90,7 @@ async def _return_async_value(val):
     return val
 
 
-class BaseTestCase(TestCase):
+class BaseTestCase(IsolatedAsyncioTestCase):
 
     def setUp(self):
         self._temp_files = []
@@ -1139,7 +1142,3 @@ class TestKubeConfigMerger(BaseTestCase):
 
         # new token
         self.assertEqual(provider.value['id-token'], "token-changed")
-
-
-if __name__ == '__main__':
-    main()

--- a/kubernetes_asyncio/config/kube_config_test.py
+++ b/kubernetes_asyncio/config/kube_config_test.py
@@ -18,12 +18,10 @@ import os
 import shutil
 import tempfile
 from types import SimpleNamespace
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import Mock, patch
 
 import yaml
-
-from unittest import IsolatedAsyncioTestCase
-from unittest.mock import patch, Mock
-
 from six import PY3
 
 from .config_exception import ConfigException

--- a/kubernetes_asyncio/config/openid_test.py
+++ b/kubernetes_asyncio/config/openid_test.py
@@ -1,14 +1,13 @@
 import asyncio
 import json
 from contextlib import contextmanager
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import patch
 
 from aiohttp import web
 from aiohttp.test_utils import (
     TestClient as _TestClient, TestServer as _TestServer,
 )
-from unittest import IsolatedAsyncioTestCase
-from unittest.mock import patch
-
 
 from .config_exception import ConfigException
 from .openid import OpenIDRequestor

--- a/kubernetes_asyncio/config/openid_test.py
+++ b/kubernetes_asyncio/config/openid_test.py
@@ -33,12 +33,8 @@ def respond_json(data):
 
 @contextmanager
 def working_client():
-    #loop = asyncio.get_event_loop()
-    loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
-
+    loop = asyncio.get_event_loop()
     app = web.Application()
-
     app.router.add_get('/.well-known/openid-configuration', respond_json({'token_endpoint': '/token'}))
     app.router.add_post('/token', respond_json({'id-token': 'id-token-data', 'refresh-token': 'refresh-token-data'}))
 
@@ -51,13 +47,8 @@ def working_client():
 
 @contextmanager
 def fail_well_known_client():
-#    loop = asyncio.get_event_loop()
-    loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
-
-
+    loop = asyncio.get_event_loop()
     app = web.Application()
-
     app.router.add_get('/.well-known/openid-configuration', make_responder(web.Response(status=500)))
 
     with patch('kubernetes_asyncio.config.openid.aiohttp.ClientSession') as _client_session:
@@ -68,12 +59,8 @@ def fail_well_known_client():
 
 @contextmanager
 def fail_token_request_client():
-#    loop = asyncio.get_event_loop()
-    loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
-
+    loop = asyncio.get_event_loop()
     app = web.Application()
-
     app.router.add_get('/.well-known/openid-configuration', respond_json({'token_endpoint': '/token'}))
     app.router.add_post('/token', make_responder(web.Response(status=500)))
 

--- a/kubernetes_asyncio/config/openid_test.py
+++ b/kubernetes_asyncio/config/openid_test.py
@@ -6,7 +6,9 @@ from aiohttp import web
 from aiohttp.test_utils import (
     TestClient as _TestClient, TestServer as _TestServer,
 )
-from asynctest import TestCase, patch
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import patch
+
 
 from .config_exception import ConfigException
 from .openid import OpenIDRequestor
@@ -31,7 +33,9 @@ def respond_json(data):
 
 @contextmanager
 def working_client():
-    loop = asyncio.get_event_loop()
+    #loop = asyncio.get_event_loop()
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
 
     app = web.Application()
 
@@ -47,7 +51,11 @@ def working_client():
 
 @contextmanager
 def fail_well_known_client():
-    loop = asyncio.get_event_loop()
+#    loop = asyncio.get_event_loop()
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+
+
     app = web.Application()
 
     app.router.add_get('/.well-known/openid-configuration', make_responder(web.Response(status=500)))
@@ -60,7 +68,10 @@ def fail_well_known_client():
 
 @contextmanager
 def fail_token_request_client():
-    loop = asyncio.get_event_loop()
+#    loop = asyncio.get_event_loop()
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+
     app = web.Application()
 
     app.router.add_get('/.well-known/openid-configuration', respond_json({'token_endpoint': '/token'}))
@@ -73,7 +84,7 @@ def fail_token_request_client():
         yield client
 
 
-class OpenIDRequestorTest(TestCase):
+class OpenIDRequestorTest(IsolatedAsyncioTestCase):
 
     def setUp(self):
         self.requestor = OpenIDRequestor(

--- a/kubernetes_asyncio/e2e_test/base.py
+++ b/kubernetes_asyncio/e2e_test/base.py
@@ -26,7 +26,8 @@ def get_e2e_configuration():
     config.host = None
     if os.path.exists(
             os.path.expanduser(kube_config.KUBE_CONFIG_DEFAULT_LOCATION)):
-        loop = asyncio.get_event_loop()
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
         loop.run_until_complete(kube_config.load_kube_config(client_configuration=config))
     else:
         print('Unable to load config from %s' %

--- a/kubernetes_asyncio/e2e_test/test_api.py
+++ b/kubernetes_asyncio/e2e_test/test_api.py
@@ -15,7 +15,7 @@
 import os
 import uuid
 
-import asynctest
+from unittest import IsolatedAsyncioTestCase
 import yaml
 
 from kubernetes_asyncio import utils
@@ -25,7 +25,7 @@ from kubernetes_asyncio.client.models import v1_delete_options
 from kubernetes_asyncio.e2e_test import base
 
 
-class TestClientApi(asynctest.TestCase):
+class TestClientApi(IsolatedAsyncioTestCase):
 
     @classmethod
     def setUpClass(cls):
@@ -136,7 +136,3 @@ spec:
 
         options = v1_delete_options.V1DeleteOptions()
         resp = await api.delete_namespaced_daemon_set(name, 'default', body=options)
-
-
-if __name__ == '__main__':
-    asynctest.main()

--- a/kubernetes_asyncio/e2e_test/test_api.py
+++ b/kubernetes_asyncio/e2e_test/test_api.py
@@ -14,8 +14,8 @@
 
 import os
 import uuid
-
 from unittest import IsolatedAsyncioTestCase
+
 import yaml
 
 from kubernetes_asyncio import utils

--- a/kubernetes_asyncio/e2e_test/test_batch.py
+++ b/kubernetes_asyncio/e2e_test/test_batch.py
@@ -14,14 +14,14 @@
 
 import uuid
 
-import asynctest
+from unittest import IsolatedAsyncioTestCase
 
 from kubernetes_asyncio.client import api_client
 from kubernetes_asyncio.client.api import batch_v1_api
 from kubernetes_asyncio.e2e_test import base
 
 
-class TestClientBatch(asynctest.TestCase):
+class TestClientBatch(IsolatedAsyncioTestCase):
 
     @classmethod
     def setUpClass(cls):
@@ -57,7 +57,3 @@ class TestClientBatch(asynctest.TestCase):
 
         resp = await api.delete_namespaced_job(
             name=name, body={}, namespace='default')
-
-
-if __name__ == '__main__':
-    asynctest.main()

--- a/kubernetes_asyncio/e2e_test/test_batch.py
+++ b/kubernetes_asyncio/e2e_test/test_batch.py
@@ -13,7 +13,6 @@
 # under the License.
 
 import uuid
-
 from unittest import IsolatedAsyncioTestCase
 
 from kubernetes_asyncio.client import api_client

--- a/kubernetes_asyncio/e2e_test/test_client.py
+++ b/kubernetes_asyncio/e2e_test/test_client.py
@@ -15,7 +15,7 @@
 import time
 import uuid
 
-import asynctest
+from unittest import IsolatedAsyncioTestCase
 
 from kubernetes_asyncio.client import api_client
 from kubernetes_asyncio.client.api import core_v1_api
@@ -28,7 +28,7 @@ def short_uuid():
     return id[-12:]
 
 
-class TestClient(asynctest.TestCase):
+class TestClient(IsolatedAsyncioTestCase):
 
     @classmethod
     def setUpClass(cls):
@@ -229,7 +229,3 @@ class TestClient(asynctest.TestCase):
             node = await api.read_node(name=item.metadata.name)
             self.assertTrue(len(node.metadata.labels) > 0)
             self.assertTrue(isinstance(node.metadata.labels, dict))
-
-
-if __name__ == '__main__':
-    asynctest.main()

--- a/kubernetes_asyncio/e2e_test/test_client.py
+++ b/kubernetes_asyncio/e2e_test/test_client.py
@@ -14,7 +14,6 @@
 
 import time
 import uuid
-
 from unittest import IsolatedAsyncioTestCase
 
 from kubernetes_asyncio.client import api_client

--- a/kubernetes_asyncio/stream/ws_client_test.py
+++ b/kubernetes_asyncio/stream/ws_client_test.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from unittest import IsolatedAsyncioTestCase
-from unittest.mock import patch, Mock
+from unittest.mock import Mock, patch
 
 from kubernetes_asyncio import client
 from kubernetes_asyncio.stream import WsApiClient

--- a/kubernetes_asyncio/stream/ws_client_test.py
+++ b/kubernetes_asyncio/stream/ws_client_test.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from asynctest import CoroutineMock, TestCase, patch
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import patch, Mock
 
 from kubernetes_asyncio import client
 from kubernetes_asyncio.stream import WsApiClient
@@ -39,7 +40,7 @@ class WsMock:
         return WsResponse(200, (chr(1) + 'mock').encode('utf-8'))
 
 
-class WSClientTest(TestCase):
+class WSClientTest(IsolatedAsyncioTestCase):
 
     def test_websocket_client(self):
         for url, ws_url in [
@@ -55,7 +56,7 @@ class WSClientTest(TestCase):
             self.assertEqual(get_websocket_url(url), ws_url)
 
     async def test_exec_ws(self):
-        mock = CoroutineMock()
+        mock = Mock()
         mock.RESTClientObject.return_value.pool_manager = mock
         mock.ws_connect.return_value = WsMock()
         with patch('kubernetes_asyncio.client.api_client.rest', mock):
@@ -82,7 +83,7 @@ class WSClientTest(TestCase):
             )
 
     async def test_exec_ws_with_heartbeat(self):
-        mock = CoroutineMock()
+        mock = Mock()
         mock.RESTClientObject.return_value.pool_manager = mock
         mock.ws_connect.return_value = WsMock()
         with patch('kubernetes_asyncio.client.api_client.rest', mock):
@@ -107,8 +108,3 @@ class WSClientTest(TestCase):
                 },
                 heartbeat=30
             )
-
-
-if __name__ == '__main__':
-    import asynctest
-    asynctest.main()

--- a/kubernetes_asyncio/utils/create_from_yaml_test.py
+++ b/kubernetes_asyncio/utils/create_from_yaml_test.py
@@ -15,7 +15,6 @@
 from unittest import IsolatedAsyncioTestCase
 from unittest.mock import AsyncMock
 
-
 from kubernetes_asyncio.utils import create_from_dict, create_from_yaml
 
 

--- a/kubernetes_asyncio/utils/create_from_yaml_test.py
+++ b/kubernetes_asyncio/utils/create_from_yaml_test.py
@@ -12,16 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from asynctest import CoroutineMock, TestCase
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock
+
 
 from kubernetes_asyncio.utils import create_from_dict, create_from_yaml
 
 
-class CreateFromYamlTest(TestCase):
+class CreateFromYamlTest(IsolatedAsyncioTestCase):
 
     async def test_create_from_yaml(self):
-        api_client = CoroutineMock()
-        api_client.call_api = CoroutineMock()
+        api_client = AsyncMock()
+        api_client.call_api = AsyncMock()
         api_client.call_api.return_value = 'mock-value'
 
         created = await create_from_yaml(api_client, 'examples/nginx-deployment.yaml')
@@ -34,8 +36,8 @@ class CreateFromYamlTest(TestCase):
         self.assertEqual(created, [['mock-value']])
 
     async def test_create_from_dict(self):
-        api_client = CoroutineMock()
-        api_client.call_api = CoroutineMock()
+        api_client = AsyncMock()
+        api_client.call_api = AsyncMock()
         api_client.call_api.return_value = 'mock-value'
 
         created = await create_from_dict(api_client, {
@@ -54,8 +56,3 @@ class CreateFromYamlTest(TestCase):
 
         # returned values
         self.assertEqual(created, ['mock-value'])
-
-
-if __name__ == '__main__':
-    import asynctest
-    asynctest.main()

--- a/kubernetes_asyncio/watch/watch_test.py
+++ b/kubernetes_asyncio/watch/watch_test.py
@@ -14,9 +14,8 @@
 
 import asyncio
 import json
-
 from unittest import IsolatedAsyncioTestCase
-from unittest.mock import call, AsyncMock, Mock
+from unittest.mock import AsyncMock, Mock, call
 
 import kubernetes_asyncio
 from kubernetes_asyncio.watch import Watch

--- a/kubernetes_asyncio/watch/watch_test.py
+++ b/kubernetes_asyncio/watch/watch_test.py
@@ -15,17 +15,18 @@
 import asyncio
 import json
 
-from asynctest import CoroutineMock, Mock, TestCase, call
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import call, AsyncMock, Mock
 
 import kubernetes_asyncio
 from kubernetes_asyncio.watch import Watch
 
 
-class WatchTest(TestCase):
+class WatchTest(IsolatedAsyncioTestCase):
 
     async def test_watch_with_decode(self):
-        fake_resp = CoroutineMock()
-        fake_resp.content.readline = CoroutineMock()
+        fake_resp = AsyncMock()
+        fake_resp.content.readline = AsyncMock()
         fake_resp.release = Mock()
         side_effects = [
             {
@@ -43,7 +44,7 @@ class WatchTest(TestCase):
         fake_resp.content.readline.side_effect = side_effects
 
         fake_api = Mock()
-        fake_api.get_namespaces = CoroutineMock(return_value=fake_resp)
+        fake_api.get_namespaces = AsyncMock(return_value=fake_resp)
         fake_api.get_namespaces.__doc__ = ':rtype: V1NamespaceList'
 
         watch = kubernetes_asyncio.watch.Watch()
@@ -71,8 +72,8 @@ class WatchTest(TestCase):
         self.assertEqual(watch.resource_version, '2')
 
     async def test_watch_for_follow(self):
-        fake_resp = CoroutineMock()
-        fake_resp.content.readline = CoroutineMock()
+        fake_resp = AsyncMock()
+        fake_resp.content.readline = AsyncMock()
         fake_resp.release = Mock()
         side_effects = ['log_line_1', 'log_line_2']
         side_effects = [_.encode('utf8') for _ in side_effects]
@@ -80,7 +81,7 @@ class WatchTest(TestCase):
         fake_resp.content.readline.side_effect = side_effects
 
         fake_api = Mock()
-        fake_api.read_namespaced_pod_log = CoroutineMock(return_value=fake_resp)
+        fake_api.read_namespaced_pod_log = AsyncMock(return_value=fake_resp)
         fake_api.read_namespaced_pod_log.__doc__ = ':param follow:\n:type follow: bool\n:rtype: str'
 
         watch = kubernetes_asyncio.watch.Watch()
@@ -106,8 +107,8 @@ class WatchTest(TestCase):
         """
         # Mock the readline return value to first return a valid response
         # followed by an empty response.
-        fake_resp = CoroutineMock()
-        fake_resp.content.readline = CoroutineMock()
+        fake_resp = AsyncMock()
+        fake_resp.content.readline = AsyncMock()
         side_effects = [
             {"type": "ADDED", "object": {"metadata": {"name": "test0"}, "spec": {}, "status": {}}},
             {"type": "ADDED", "object": {"metadata": {"name": "test1"}, "spec": {}, "status": {}}},
@@ -117,7 +118,7 @@ class WatchTest(TestCase):
 
         # Fake the K8s resource object to watch.
         fake_api = Mock()
-        fake_api.get_namespaces = CoroutineMock(return_value=fake_resp)
+        fake_api.get_namespaces = AsyncMock(return_value=fake_resp)
         fake_api.get_namespaces.__doc__ = ':rtype: V1NamespaceList'
 
         # Iteration must cease after all valid responses were received.
@@ -215,11 +216,11 @@ class WatchTest(TestCase):
         self.assertEqual("1", w.resource_version)
 
     async def test_watch_with_exception(self):
-        fake_resp = CoroutineMock()
-        fake_resp.content.readline = CoroutineMock()
+        fake_resp = AsyncMock()
+        fake_resp.content.readline = AsyncMock()
         fake_resp.content.readline.side_effect = KeyError("expected")
         fake_api = Mock()
-        fake_api.get_namespaces = CoroutineMock(return_value=fake_resp)
+        fake_api.get_namespaces = AsyncMock(return_value=fake_resp)
         fake_api.get_namespaces.__doc__ = ':rtype: V1NamespaceList'
 
         with self.assertRaises(KeyError):
@@ -228,8 +229,8 @@ class WatchTest(TestCase):
                 pass
 
     async def test_watch_timeout(self):
-        fake_resp = CoroutineMock()
-        fake_resp.content.readline = CoroutineMock()
+        fake_resp = AsyncMock()
+        fake_resp.content.readline = AsyncMock()
         fake_resp.release = Mock()
 
         mock_event = {"type": "ADDED",
@@ -243,7 +244,7 @@ class WatchTest(TestCase):
                                                   b""]
 
         fake_api = Mock()
-        fake_api.get_namespaces = CoroutineMock(return_value=fake_resp)
+        fake_api.get_namespaces = AsyncMock(return_value=fake_resp)
         fake_api.get_namespaces.__doc__ = ':rtype: V1NamespaceList'
 
         watch = kubernetes_asyncio.watch.Watch()
@@ -257,15 +258,15 @@ class WatchTest(TestCase):
         fake_resp.release.assert_called_once_with()
 
     async def test_watch_timeout_with_resource_version(self):
-        fake_resp = CoroutineMock()
-        fake_resp.content.readline = CoroutineMock()
+        fake_resp = AsyncMock()
+        fake_resp.content.readline = AsyncMock()
         fake_resp.release = Mock()
 
         fake_resp.content.readline.side_effect = [asyncio.TimeoutError(),
                                                   b""]
 
         fake_api = Mock()
-        fake_api.get_namespaces = CoroutineMock(return_value=fake_resp)
+        fake_api.get_namespaces = AsyncMock(return_value=fake_resp)
         fake_api.get_namespaces.__doc__ = ':rtype: V1NamespaceList'
 
         watch = kubernetes_asyncio.watch.Watch()
@@ -280,8 +281,3 @@ class WatchTest(TestCase):
 
         fake_resp.release.assert_called_once_with()
         self.assertEqual(watch.resource_version, '10')
-
-
-if __name__ == '__main__':
-    import asynctest
-    asynctest.main()

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,8 +1,6 @@
-asynctest
 codecov>=1.4.0
 flake8
 isort
-mock>=2.0.0
 pluggy>=0.3.1
 py>=1.4.31
 pytest

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,3 @@
-codecov>=1.4.0
 flake8
 isort
 pluggy>=0.3.1


### PR DESCRIPTION
* replace asynctest with unittest (Python 3.8+) - it fixes https://github.com/tomplus/kubernetes_asyncio/issues/234
* replace codecov with github actions codecov/codecov-actions to upload cov reports