### PR TITLE
Change K8s version from 1.23.6 to 1.26.3 in e2e tests.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -38,7 +38,7 @@ jobs:
 
     - name: Run e2e tests
       run: |
-        apt-get install -y conntrack
+        sudo apt-get install -y conntrack
         scripts/kube-init.sh py.test -vvv -s kubernetes_asyncio/e2e_test
 
     - name: Lint with flake8 and isort (only on the latest version of Python)

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -38,6 +38,7 @@ jobs:
 
     - name: Run e2e tests
       run: |
+        apt-get install -y conntrack
         scripts/kube-init.sh py.test -vvv -s kubernetes_asyncio/e2e_test
 
     - name: Lint with flake8 and isort (only on the latest version of Python)

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -38,7 +38,6 @@ jobs:
 
     - name: Run e2e tests
       run: |
-        sudo apt-get install -y conntrack
         scripts/kube-init.sh py.test -vvv -s kubernetes_asyncio/e2e_test
 
     - name: Lint with flake8 and isort (only on the latest version of Python)

--- a/scripts/kube-init.sh
+++ b/scripts/kube-init.sh
@@ -61,18 +61,18 @@ wget -O kubectl "http://storage.googleapis.com/kubernetes-release/release/${K8S_
 sudo chmod +x kubectl
 sudo mv kubectl /usr/local/bin/
 
-echo "Download  CRI tools"
-CRI_VERSION="v1.27.0"
-wget https://github.com/kubernetes-sigs/cri-tools/releases/download/$CRI_VERSION/crictl-$CRI_VERSION-linux-amd64.tar.gz
-sudo tar zxvf crictl-$CRI_VERSION-linux-amd64.tar.gz -C /usr/local/bin
-rm -f crictl-$CRI_VERSION-linux-amd64.tar.gz
+#echo "Download  CRI tools"
+#CRI_VERSION="v1.27.0"
+#wget https://github.com/kubernetes-sigs/cri-tools/releases/download/$CRI_VERSION/crictl-$CRI_VERSION-linux-amd64.tar.gz
+#sudo tar zxvf crictl-$CRI_VERSION-linux-amd64.tar.gz -C /usr/local/bin
+#rm -f crictl-$CRI_VERSION-linux-amd64.tar.gz
 
-echo "Download CRI Dockerd"
-CRI_DOCKERD_VERSION="0.3.2"
-RELEASE_CODENAME=$(lsb_release --short --codename)
-wget https://github.com/Mirantis/cri-dockerd/releases/download/v$CRI_DOCKERD_VERSION/cri-dockerd_$CRI_DOCKERD_VERSION.3-0.ubuntu-${RELEASE_CODENAME}_amd64.deb
-sudo dpkg -i cri-dockerd_$CRI_DOCKERD_VERSION.3-0.ubuntu-${RELEASE_CODENAME}_amd64.deb
-rm -f cri-dockerd_$CRI_DOCKERD_VERSION.3-0.ubuntu-${RELEASE_CODENAME}_amd64.deb
+#echo "Download CRI Dockerd"
+#CRI_DOCKERD_VERSION="0.3.2"
+#RELEASE_CODENAME=$(lsb_release --short --codename)
+#wget https://github.com/Mirantis/cri-dockerd/releases/download/v$CRI_DOCKERD_VERSION/cri-dockerd_$CRI_DOCKERD_VERSION.3-0.ubuntu-${RELEASE_CODENAME}_amd64.deb
+#sudo dpkg -i cri-dockerd_$CRI_DOCKERD_VERSION.3-0.ubuntu-${RELEASE_CODENAME}_amd64.deb
+#rm -f cri-dockerd_$CRI_DOCKERD_VERSION.3-0.ubuntu-${RELEASE_CODENAME}_amd64.deb
 
 echo "Download localkube from minikube project"
 wget -O minikube "https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64"
@@ -85,18 +85,18 @@ echo "Set up minikube"
 export MINIKUBE_WANTUPDATENOTIFICATION=false
 export MINIKUBE_WANTREPORTERRORPROMPT=false
 export CHANGE_MINIKUBE_NONE_USER=true
-mkdir -p $HOME/.kube
-mkdir -p $HOME/.minikube
+sudo mkdir -p $HOME/.kube
+sudo mkdir -p $HOME/.minikube
 export MINIKUBE_HOME=$HOME
 export MINIKUBE_DRIVER=${MINIKUBE_DRIVER:-none}
 # Used bootstrapper to be kubeadm for the most recent k8s version
 # since localkube is depreciated and only supported up to version 1.10.0
 echo "Starting minikube"
 #sudo --preserve-env=MINIKUBE_HOME --preserve-env=HOME minikube start --vm-driver=$MINIKUBE_DRIVER --bootstrapper=kubeadm --kubernetes-version=$K8S_VERSION --logtostderr -v8 --wait=all
-minikube start --bootstrapper=kubeadm --logtostderr -v8 --wait=all
+sudo --preserve-env=MINIKUBE_HOME --preserve-env=HOME minikube start --bootstrapper=kubeadm --logtostderr -v8 --wait=all --force
 
 # Update ownership for configs/certs
-#sudo chown -R $USER /home/runner/.minikube /home/runner/.kube
+sudo chown -R $USER /home/runner/.minikube /home/runner/.kube
 
 echo "Dump kube config"
 kubectl config view
@@ -104,7 +104,7 @@ kubectl config view
 # check if kubectl can access the api server that Minikube has created
 kubectl get po &> /dev/null
 if [ $? -eq 1 ]; then
-  minikube logs
+  sudo minikube logs
   echo "minikube did not start"
   exit 1
 fi

--- a/scripts/kube-init.sh
+++ b/scripts/kube-init.sh
@@ -61,6 +61,12 @@ wget -O kubectl "http://storage.googleapis.com/kubernetes-release/release/${K8S_
 sudo chmod +x kubectl
 sudo mv kubectl /usr/local/bin/
 
+echo "Download  CRI tools"
+CRI_VERSION="v1.27.0"
+wget https://github.com/kubernetes-sigs/cri-tools/releases/download/$CRI_VERSION/crictl-$CRI_VERSION-linux-amd64.tar.gz
+sudo tar zxvf crictl-$CRI_VERSION-linux-amd64.tar.gz -C /usr/local/bin
+rm -f crictl-$CRI_VERSION-linux-amd64.tar.gz
+
 echo "Download localkube from minikube project"
 wget -O minikube "https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64"
 sudo chmod +x minikube

--- a/scripts/kube-init.sh
+++ b/scripts/kube-init.sh
@@ -93,7 +93,7 @@ export MINIKUBE_DRIVER=${MINIKUBE_DRIVER:-none}
 # since localkube is depreciated and only supported up to version 1.10.0
 echo "Starting minikube"
 #sudo --preserve-env=MINIKUBE_HOME --preserve-env=HOME minikube start --vm-driver=$MINIKUBE_DRIVER --bootstrapper=kubeadm --kubernetes-version=$K8S_VERSION --logtostderr -v8 --wait=all
-sudo --preserve-env=MINIKUBE_HOME --preserve-env=HOME minikube start --bootstrapper=kubeadm --logtostderr -v8 --wait=all --force
+minikube start --bootstrapper=kubeadm --logtostderr -v8 --wait=all
 
 # Update ownership for configs/certs
 sudo chown -R $USER /home/runner/.minikube /home/runner/.kube

--- a/scripts/kube-init.sh
+++ b/scripts/kube-init.sh
@@ -93,7 +93,7 @@ export MINIKUBE_DRIVER=${MINIKUBE_DRIVER:-none}
 # since localkube is depreciated and only supported up to version 1.10.0
 echo "Starting minikube"
 #sudo --preserve-env=MINIKUBE_HOME --preserve-env=HOME minikube start --vm-driver=$MINIKUBE_DRIVER --bootstrapper=kubeadm --kubernetes-version=$K8S_VERSION --logtostderr -v8 --wait=all
-sudo --preserve-env=MINIKUBE_HOME --preserve-env=HOME minikube start --bootstrapper=kubeadm --logtostderr -v8 --wait=all
+sudo --preserve-env=MINIKUBE_HOME --preserve-env=HOME minikube start --bootstrapper=kubeadm --logtostderr -v8 --wait=all --force
 
 # Update ownership for configs/certs
 sudo chown -R $USER /home/runner/.minikube /home/runner/.kube

--- a/scripts/kube-init.sh
+++ b/scripts/kube-init.sh
@@ -88,12 +88,12 @@ export CHANGE_MINIKUBE_NONE_USER=true
 sudo mkdir -p $HOME/.kube
 sudo mkdir -p $HOME/.minikube
 export MINIKUBE_HOME=$HOME
-export MINIKUBE_DRIVER=${MINIKUBE_DRIVER:-none}
+export MINIKUBE_DRIVER=${MINIKUBE_DRIVER:-docker}
 # Used bootstrapper to be kubeadm for the most recent k8s version
 # since localkube is depreciated and only supported up to version 1.10.0
 echo "Starting minikube"
-#sudo --preserve-env=MINIKUBE_HOME --preserve-env=HOME minikube start --vm-driver=$MINIKUBE_DRIVER --bootstrapper=kubeadm --kubernetes-version=$K8S_VERSION --logtostderr -v8 --wait=all
-sudo --preserve-env=MINIKUBE_HOME --preserve-env=HOME minikube start --bootstrapper=kubeadm --logtostderr -v8 --wait=all --force
+sudo --preserve-env=MINIKUBE_HOME --preserve-env=HOME minikube start --vm-driver=$MINIKUBE_DRIVER --bootstrapper=kubeadm --kubernetes-version=$K8S_VERSION --logtostderr -v8 --wait=all
+#sudo --preserve-env=MINIKUBE_HOME --preserve-env=HOME minikube start --bootstrapper=kubeadm --kubernetes-version=$K8S_VERSION --logtostderr -v8 --wait=all --force
 
 # Update ownership for configs/certs
 sudo chown -R $USER /home/runner/.minikube /home/runner/.kube

--- a/scripts/kube-init.sh
+++ b/scripts/kube-init.sh
@@ -87,7 +87,7 @@ export MINIKUBE_DRIVER=${MINIKUBE_DRIVER:-docker}
 # Used bootstrapper to be kubeadm for the most recent k8s version
 # since localkube is depreciated and only supported up to version 1.10.0
 echo "Starting minikube"
-sudo --preserve-env=MINIKUBE_HOME --preserve-env=HOME minikube start --vm-driver=$MINIKUBE_DRIVER --bootstrapper=kubeadm --kubernetes-version=$K8S_VERSION --logtostderr -v8 --wait=all
+sudo --preserve-env=MINIKUBE_HOME --preserve-env=HOME minikube start --vm-driver=$MINIKUBE_DRIVER --bootstrapper=kubeadm --kubernetes-version=$K8S_VERSION --logtostderr --wait=all --force
 
 # Update ownership for configs/certs
 sudo chown -R $USER /home/runner/.minikube /home/runner/.kube

--- a/scripts/kube-init.sh
+++ b/scripts/kube-init.sh
@@ -50,6 +50,10 @@ docker --version
 K8S_VERSION=$(curl -sSL https://dl.k8s.io/release/stable.txt)
 echo "K8S_VERSION : ${K8S_VERSION}"
 
+# but minikube returns: Specified Kubernetes version 1.27.1 is newer than the newest supported version: v1.27.0-rc.0. 
+K8S_VERSION="1.26.3"
+echo "K8S_VERSION : ${K8S_VERSION}"
+
 echo "Starting docker service"
 sudo systemctl enable docker.service
 sudo systemctl start docker.service --ignore-dependencies
@@ -60,19 +64,6 @@ echo "Download Kubernetes CLI"
 wget -O kubectl "http://storage.googleapis.com/kubernetes-release/release/${K8S_VERSION}/bin/linux/amd64/kubectl"
 sudo chmod +x kubectl
 sudo mv kubectl /usr/local/bin/
-
-#echo "Download  CRI tools"
-#CRI_VERSION="v1.27.0"
-#wget https://github.com/kubernetes-sigs/cri-tools/releases/download/$CRI_VERSION/crictl-$CRI_VERSION-linux-amd64.tar.gz
-#sudo tar zxvf crictl-$CRI_VERSION-linux-amd64.tar.gz -C /usr/local/bin
-#rm -f crictl-$CRI_VERSION-linux-amd64.tar.gz
-
-#echo "Download CRI Dockerd"
-#CRI_DOCKERD_VERSION="0.3.2"
-#RELEASE_CODENAME=$(lsb_release --short --codename)
-#wget https://github.com/Mirantis/cri-dockerd/releases/download/v$CRI_DOCKERD_VERSION/cri-dockerd_$CRI_DOCKERD_VERSION.3-0.ubuntu-${RELEASE_CODENAME}_amd64.deb
-#sudo dpkg -i cri-dockerd_$CRI_DOCKERD_VERSION.3-0.ubuntu-${RELEASE_CODENAME}_amd64.deb
-#rm -f cri-dockerd_$CRI_DOCKERD_VERSION.3-0.ubuntu-${RELEASE_CODENAME}_amd64.deb
 
 echo "Download localkube from minikube project"
 wget -O minikube "https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64"

--- a/scripts/kube-init.sh
+++ b/scripts/kube-init.sh
@@ -69,9 +69,10 @@ rm -f crictl-$CRI_VERSION-linux-amd64.tar.gz
 
 echo "Download CRI Dockerd"
 CRI_DOCKERD_VERSION="0.3.2"
-wget https://github.com/Mirantis/cri-dockerd/releases/download/v$CRI_DOCKERD_VERSION/cri-dockerd-$CRI_DOCKERD_VERSION.amd64.tgz
-sudo tar zxvf cri-dockerd-$CRI_DOCKERD_VERSION.amd64.tgz --strip-components=1 -C /usr/local/bin
-rm -f cri-dockerd-$CRI_DOCKERD_VERSION.amd64.tgz
+RELEASE_CODENAME=$(lsb_release --short --codename)
+wget https://github.com/Mirantis/cri-dockerd/releases/download/v$CRI_DOCKERD_VERSION/cri-dockerd_$CRI_DOCKERD_VERSION.3-0.ubuntu-${RELEASE_CODENAME}_amd64.deb
+sudo dpkg -i cri-dockerd_$CRI_DOCKERD_VERSION.3-0.ubuntu-${RELEASE_CODENAME}_amd64.deb
+rm -f cri-dockerd_$CRI_DOCKERD_VERSION.3-0.ubuntu-${RELEASE_CODENAME}_amd64.deb
 
 echo "Download localkube from minikube project"
 wget -O minikube "https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64"

--- a/scripts/kube-init.sh
+++ b/scripts/kube-init.sh
@@ -47,10 +47,7 @@ fi
 docker --version
 
 # Get the latest stable version of kubernetes
-#K8S_VERSION=$(curl -sS https://storage.googleapis.com/kubernetes-release/release/stable.txt)
-# Problem with 1.24.0 in minikube, https://github.com/kubernetes/minikube/issues/14128
-# pin to previous version
-K8S_VERSION=1.23.6
+K8S_VERSION=$(curl -sS https://dl.k8s.io/release/stable.txt)
 echo "K8S_VERSION : ${K8S_VERSION}"
 
 echo "Starting docker service"

--- a/scripts/kube-init.sh
+++ b/scripts/kube-init.sh
@@ -85,8 +85,8 @@ echo "Set up minikube"
 export MINIKUBE_WANTUPDATENOTIFICATION=false
 export MINIKUBE_WANTREPORTERRORPROMPT=false
 export CHANGE_MINIKUBE_NONE_USER=true
-sudo mkdir -p $HOME/.kube
-sudo mkdir -p $HOME/.minikube
+mkdir -p $HOME/.kube
+mkdir -p $HOME/.minikube
 export MINIKUBE_HOME=$HOME
 export MINIKUBE_DRIVER=${MINIKUBE_DRIVER:-none}
 # Used bootstrapper to be kubeadm for the most recent k8s version
@@ -96,7 +96,7 @@ echo "Starting minikube"
 minikube start --bootstrapper=kubeadm --logtostderr -v8 --wait=all
 
 # Update ownership for configs/certs
-sudo chown -R $USER /home/runner/.minikube /home/runner/.kube
+#sudo chown -R $USER /home/runner/.minikube /home/runner/.kube
 
 echo "Dump kube config"
 kubectl config view
@@ -104,7 +104,7 @@ kubectl config view
 # check if kubectl can access the api server that Minikube has created
 kubectl get po &> /dev/null
 if [ $? -eq 1 ]; then
-  sudo minikube logs
+  minikube logs
   echo "minikube did not start"
   exit 1
 fi

--- a/scripts/kube-init.sh
+++ b/scripts/kube-init.sh
@@ -51,7 +51,7 @@ K8S_VERSION=$(curl -sSL https://dl.k8s.io/release/stable.txt)
 echo "K8S_VERSION : ${K8S_VERSION}"
 
 # but minikube returns: Specified Kubernetes version 1.27.1 is newer than the newest supported version: v1.27.0-rc.0. 
-K8S_VERSION="1.26.3"
+K8S_VERSION="v1.26.3"
 echo "K8S_VERSION : ${K8S_VERSION}"
 
 echo "Starting docker service"
@@ -62,6 +62,10 @@ sudo docker ps
 
 echo "Download Kubernetes CLI"
 wget -O kubectl "http://storage.googleapis.com/kubernetes-release/release/${K8S_VERSION}/bin/linux/amd64/kubectl"
+if [ $? -ne 0 ]; then
+    echo "failed to download kubectl"
+    exit 1
+fi
 sudo chmod +x kubectl
 sudo mv kubectl /usr/local/bin/
 
@@ -84,7 +88,6 @@ export MINIKUBE_DRIVER=${MINIKUBE_DRIVER:-docker}
 # since localkube is depreciated and only supported up to version 1.10.0
 echo "Starting minikube"
 sudo --preserve-env=MINIKUBE_HOME --preserve-env=HOME minikube start --vm-driver=$MINIKUBE_DRIVER --bootstrapper=kubeadm --kubernetes-version=$K8S_VERSION --logtostderr -v8 --wait=all
-#sudo --preserve-env=MINIKUBE_HOME --preserve-env=HOME minikube start --bootstrapper=kubeadm --kubernetes-version=$K8S_VERSION --logtostderr -v8 --wait=all --force
 
 # Update ownership for configs/certs
 sudo chown -R $USER /home/runner/.minikube /home/runner/.kube

--- a/scripts/kube-init.sh
+++ b/scripts/kube-init.sh
@@ -92,7 +92,8 @@ export MINIKUBE_DRIVER=${MINIKUBE_DRIVER:-none}
 # Used bootstrapper to be kubeadm for the most recent k8s version
 # since localkube is depreciated and only supported up to version 1.10.0
 echo "Starting minikube"
-sudo --preserve-env=MINIKUBE_HOME --preserve-env=HOME minikube start --vm-driver=$MINIKUBE_DRIVER --bootstrapper=kubeadm --kubernetes-version=$K8S_VERSION --logtostderr -v8 --wait=all
+#sudo --preserve-env=MINIKUBE_HOME --preserve-env=HOME minikube start --vm-driver=$MINIKUBE_DRIVER --bootstrapper=kubeadm --kubernetes-version=$K8S_VERSION --logtostderr -v8 --wait=all
+sudo --preserve-env=MINIKUBE_HOME --preserve-env=HOME minikube start --bootstrapper=kubeadm --logtostderr -v8 --wait=all
 
 # Update ownership for configs/certs
 sudo chown -R $USER /home/runner/.minikube /home/runner/.kube

--- a/scripts/kube-init.sh
+++ b/scripts/kube-init.sh
@@ -67,6 +67,12 @@ wget https://github.com/kubernetes-sigs/cri-tools/releases/download/$CRI_VERSION
 sudo tar zxvf crictl-$CRI_VERSION-linux-amd64.tar.gz -C /usr/local/bin
 rm -f crictl-$CRI_VERSION-linux-amd64.tar.gz
 
+echo "Download CRI Dockerd"
+CRI_DOCKERD_VERSION="0.3.2"
+wget https://github.com/Mirantis/cri-dockerd/releases/download/v$CRI_DOCKERD_VERSION/cri-dockerd-$CRI_DOCKERD_VERSION.amd64.tgz
+sudo tar zxvf cri-dockerd-$CRI_DOCKERD_VERSION.amd64.tgz --strip-components=1 -C /usr/local/bin
+rm -f cri-dockerd-$CRI_DOCKERD_VERSION.amd64.tgz
+
 echo "Download localkube from minikube project"
 wget -O minikube "https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64"
 sudo chmod +x minikube

--- a/scripts/kube-init.sh
+++ b/scripts/kube-init.sh
@@ -47,7 +47,7 @@ fi
 docker --version
 
 # Get the latest stable version of kubernetes
-K8S_VERSION=$(curl -sS https://dl.k8s.io/release/stable.txt)
+K8S_VERSION=$(curl -sSL https://dl.k8s.io/release/stable.txt)
 echo "K8S_VERSION : ${K8S_VERSION}"
 
 echo "Starting docker service"


### PR DESCRIPTION
1. change driver to docker (simpler to use in github actions)
2.  k8s v1.27 is not supported by mini-kube yet