### PR TITLE
[fix] support refreshing exec api credentials

### DIFF
--- a/examples/tail.py
+++ b/examples/tail.py
@@ -14,7 +14,7 @@ import argparse
 import asyncio
 
 from kubernetes_asyncio import client, config
-from kubernetes_asyncio.client.api_client import ApiClient
+from kubernetes_asyncio.client.api_client import ApiClient, Configuration
 
 
 def parse_args():
@@ -51,8 +51,9 @@ async def print_pod_log(v1_api, pod, namespace, container, lines, follow):
 async def main():
     args = parse_args()
 
-    loader = await config.load_kube_config()
-    api = ApiClient()
+    client_configuration = Configuration()
+    loader = await config.load_kube_config(client_configuration=client_configuration)
+    api = ApiClient(configuration=client_configuration)
     v1_api = client.CoreV1Api(api)
     ret = await v1_api.list_namespaced_pod(args.namespace)
     cmd = []
@@ -72,7 +73,9 @@ async def main():
 
     if args.follow:
         # autorefresh gcp token
-        cmd.append(config.refresh_token(loader))
+        cmd.append(config.refresh_token(
+            loader=loader,
+            client_configuration=client_configuration))
 
     await asyncio.wait(cmd)
     await api.close()


### PR DESCRIPTION
Fixes #257. This PR is based heavily on https://github.com/kubernetes-client/python-base/pull/250. It also includes the fix made [here](https://github.com/kubernetes-client/python/commit/a07531b93233a9565d973d861dc711fa26b17cc8) to the non-asyncio library. 

This change has been tested in multiple services that rely on a long running client that was previously failing due to expiring credentials.