### PR TITLE
Load certificates from plugin exec

### DIFF
--- a/kubernetes_asyncio/config/kube_config.py
+++ b/kubernetes_asyncio/config/kube_config.py
@@ -313,11 +313,33 @@ class KubeConfigLoader(object):
         try:
             if hasattr(self, 'exec_plugin_expiry') and not _is_expired(self.exec_plugin_expiry):
                 return True
+            base_path = self._get_base_path(self._cluster.path)
             status = await ExecProvider(self._user['exec']).run()
-            if 'token' not in status:
-                logging.error('exec: missing token field in plugin output')
+            if 'token' in status:
+                self.token = "Bearer %s" % status['token']
+            elif 'clientCertificateData' in status:
+                # https://kubernetes.io/docs/reference/access-authn-authz/authentication/#input-and-output-formats
+                # Plugin has provided certificates instead of a token.
+                if 'clientKeyData' not in status:
+                    logging.error('exec: missing clientKeyData field in '
+                                  'plugin output')
+                    return None
+                self.cert_file = FileOrData(
+                    status, None,
+                    data_key_name='clientCertificateData',
+                    file_base_path=base_path,
+                    base64_file_content=False,
+                    temp_file_path=self._temp_file_path).as_file()
+                self.key_file = FileOrData(
+                    status, None,
+                    data_key_name='clientKeyData',
+                    file_base_path=base_path,
+                    base64_file_content=False,
+                    temp_file_path=self._temp_file_path).as_file()
+            else:
+                logging.error('exec: missing token or clientCertificateData '
+                              'field in plugin output')
                 return None
-            self.token = "Bearer %s" % status['token']
             if 'expirationTimestamp' in status:
                 self.exec_plugin_expiry = parse_rfc3339(status['expirationTimestamp'])
             return True
@@ -357,14 +379,18 @@ class KubeConfigLoader(object):
                     self._cluster, 'certificate-authority',
                     file_base_path=base_path,
                     temp_file_path=self._temp_file_path).as_file()
-                self.cert_file = FileOrData(
-                    self._user, 'client-certificate',
-                    file_base_path=base_path,
-                    temp_file_path=self._temp_file_path).as_file()
-                self.key_file = FileOrData(
-                    self._user, 'client-key',
-                    file_base_path=base_path,
-                    temp_file_path=self._temp_file_path).as_file()
+                if 'cert_file' not in self.__dict__:
+                    # cert_file could have been provided by
+                    # _load_from_exec_plugin; only load from the _user
+                    # section if we need it.
+                    self.cert_file = FileOrData(
+                        self._user, 'client-certificate',
+                        file_base_path=base_path,
+                        temp_file_path=self._temp_file_path).as_file()
+                    self.key_file = FileOrData(
+                        self._user, 'client-key',
+                        file_base_path=base_path,
+                        temp_file_path=self._temp_file_path).as_file()
         if 'insecure-skip-tls-verify' in self._cluster:
             self.verify_ssl = not self._cluster['insecure-skip-tls-verify']
 

--- a/kubernetes_asyncio/config/kube_config.py
+++ b/kubernetes_asyncio/config/kube_config.py
@@ -317,6 +317,8 @@ class KubeConfigLoader(object):
             status = await ExecProvider(self._user['exec']).run()
             if 'token' in status:
                 self.token = "Bearer %s" % status['token']
+                if 'expirationTimestamp' in status:
+                    self.exec_plugin_expiry = parse_rfc3339(status['expirationTimestamp'])
             elif 'clientCertificateData' in status:
                 # https://kubernetes.io/docs/reference/access-authn-authz/authentication/#input-and-output-formats
                 # Plugin has provided certificates instead of a token.
@@ -340,8 +342,6 @@ class KubeConfigLoader(object):
                 logging.error('exec: missing token or clientCertificateData '
                               'field in plugin output')
                 return None
-            if 'expirationTimestamp' in status:
-                self.exec_plugin_expiry = parse_rfc3339(status['expirationTimestamp'])
             return True
         except Exception as e:
             logging.error(str(e))

--- a/kubernetes_asyncio/config/kube_config_test.py
+++ b/kubernetes_asyncio/config/kube_config_test.py
@@ -794,7 +794,6 @@ class TestKubeConfigLoader(BaseTestCase):
             active_context="exec_cred_user_certificate").load_and_set(actual)
         self.assertEqual(expected, actual)
 
-
     async def test_user_pass(self):
         expected = FakeConfig(host=TEST_HOST, token=TEST_BASIC_TOKEN)
         actual = FakeConfig()


### PR DESCRIPTION
This mostly imports what was done in the sync client in https://github.com/kubernetes-client/python/commit/b85aff2b3e6c950cb9128d281cd6f7394563e202

This may solve #231: if the configuration from #213 was trying to load a configuration file containing these client certificates instead of a bearer token, the log message would display and the connection to Kubernetes would fail.