### PR TITLE
Support loading a custom TLS server name from `kubeconfig`

### DIFF
--- a/kubernetes_asyncio/client/configuration.py
+++ b/kubernetes_asyncio/client/configuration.py
@@ -189,6 +189,10 @@ conf = client.Configuration(
         self.assert_hostname = None
         """Set this to True/False to enable/disable SSL hostname verification.
         """
+        self.tls_server_name = None
+        """SSL/TLS Server Name Indication (SNI)
+           Set this to the SNI value expected by Kubernetes API.
+        """
 
         self.connection_pool_maxsize = 100
         """This value is passed to the aiohttp to limit simultaneous connections.

--- a/kubernetes_asyncio/client/rest.py
+++ b/kubernetes_asyncio/client/rest.py
@@ -56,6 +56,8 @@ class RESTClientObject(object):
                 configuration.cert_file, keyfile=configuration.key_file
             )
 
+        self.server_hostname = configuration.tls_server_name
+
         if not configuration.verify_ssl:
             ssl_context.check_hostname = False
             ssl_context.verify_mode = ssl.CERT_NONE
@@ -134,6 +136,9 @@ class RESTClientObject(object):
 
         if query_params:
             args["url"] += '?' + urlencode(query_params)
+
+        if self.server_hostname:
+            args["server_hostname"] = self.server_hostname
 
         # For `POST`, `PUT`, `PATCH`, `OPTIONS`, `DELETE`
         if method in ['POST', 'PUT', 'PATCH', 'OPTIONS', 'DELETE']:

--- a/kubernetes_asyncio/config/kube_config.py
+++ b/kubernetes_asyncio/config/kube_config.py
@@ -393,6 +393,8 @@ class KubeConfigLoader(object):
                         temp_file_path=self._temp_file_path).as_file()
         if 'insecure-skip-tls-verify' in self._cluster:
             self.verify_ssl = not self._cluster['insecure-skip-tls-verify']
+        if 'tls-server-name' in self._cluster:
+            self.tls_server_name = self._cluster['tls-server-name']
 
     def _set_config(self, client_configuration):
 
@@ -400,7 +402,7 @@ class KubeConfigLoader(object):
             client_configuration.api_key['BearerToken'] = self.token
 
         # copy these keys directly from self to configuration object
-        keys = ['host', 'ssl_ca_cert', 'cert_file', 'key_file', 'verify_ssl']
+        keys = ['host', 'ssl_ca_cert', 'cert_file', 'key_file', 'verify_ssl', 'tls_server_name']
         for key in keys:
             if key in self.__dict__:
                 setattr(client_configuration, key, getattr(self, key))

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ python-dateutil>=2.5.3  # BSD
 setuptools>=21.0.0  # PSF/ZPL
 urllib3>=1.24.2  # MIT
 pyyaml>=3.12  # MIT
-aiohttp>=3.7.0,<4.0.0 # # Apache-2.0
+aiohttp>=3.9.0,<4.0.0 # # Apache-2.0

--- a/scripts/rest_client_server_hostname_patch.diff
+++ b/scripts/rest_client_server_hostname_patch.diff
@@ -1,0 +1,23 @@
+diff --git a/kubernetes_asyncio/client/rest.py b/kubernetes_asyncio/client/rest.py
+index c5be7990..9e0daab4 100644
+--- a/kubernetes_asyncio/client/rest.py
++++ b/kubernetes_asyncio/client/rest.py
+@@ -56,6 +56,8 @@ class RESTClientObject(object):
+                 configuration.cert_file, keyfile=configuration.key_file
+             )
+ 
++        self.server_hostname = configuration.tls_server_name
++
+         if not configuration.verify_ssl:
+             ssl_context.check_hostname = False
+             ssl_context.verify_mode = ssl.CERT_NONE
+@@ -135,6 +137,9 @@ class RESTClientObject(object):
+         if query_params:
+             args["url"] += '?' + urlencode(query_params)
+ 
++        if self.server_hostname:
++            args["server_hostname"] = self.server_hostname
++
+         # For `POST`, `PUT`, `PATCH`, `OPTIONS`, `DELETE`
+         if method in ['POST', 'PUT', 'PATCH', 'OPTIONS', 'DELETE']:
+             if re.search('json', headers['Content-Type'], re.IGNORECASE):

--- a/scripts/update-client.sh
+++ b/scripts/update-client.sh
@@ -68,6 +68,8 @@ echo ">>> fix generated rest client for patching with strategic merge..."
 patch "${CLIENT_ROOT}/client/rest.py" "${SCRIPT_ROOT}/rest_client_patch.diff"
 echo ">>> fix generated rest client by increasing aiohttp read buffer to 2MiB..."
 patch "${CLIENT_ROOT}/client/rest.py" "${SCRIPT_ROOT}/rest_client_patch_read_bufsize.diff"
+echo ">>> fix generated rest client to support customer server hostname TLS verification..."
+patch "${CLIENT_ROOT}/client/rest.py" "${SCRIPT_ROOT}/rest_client_server_hostname_patch.diff"
 
 
 echo ">>> Remove invalid tests (workaround https://github.com/OpenAPITools/openapi-generator/issues/5377)"


### PR DESCRIPTION
This honors the `tls-server-name` parameter which can be present in a `kubeconfig` configuration file.

The implementation is similar to the one done in https://github.com/kubernetes-client/python/pull/1933

~This needs a released version of https://github.com/aio-libs/aiohttp/pull/7541~ This is implemented in [aiohttp v3.9.0](https://github.com/aio-libs/aiohttp/pull/7543).

Fix: #267 