### PR TITLE
Add basic retries to REST requests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ setuptools>=21.0.0  # PSF/ZPL
 urllib3>=1.24.2  # MIT
 pyyaml>=3.12  # MIT
 aiohttp>=3.7.0,<4.0.0 # # Apache-2.0
+aiohttp-retry  # MIT


### PR DESCRIPTION
This PR adds basic support for retries on REST API calls using aiohttp-retry library to resolve https://github.com/tomplus/kubernetes_asyncio/issues/288 

It attempts to replicate the behaviour of the sync client which uses urllib3 basic retry with a count for retries and does not retry on POST requests.

The pool_manager is not created as a RetryClient because this caused an issue with the WsApiClient since RetryClient does not have the `ws_connect` method. 