### PR TITLE
add bookmark support in watcher

### DIFF
--- a/kubernetes_asyncio/watch/watch.py
+++ b/kubernetes_asyncio/watch/watch.py
@@ -104,7 +104,7 @@ class Watch(object):
 
         # If possible, compile the JSON response into a Python native response
         # type, eg `V1Namespace` or `V1Pod`,`ExtensionsV1beta1Deployment`, ...
-        if response_type:
+        if response_type and js['type'].lower() != 'bookmark':
             js['object'] = self._api_client.deserialize(
                 response=SimpleNamespace(data=json.dumps(js['raw_object'])),
                 response_type=response_type
@@ -120,6 +120,8 @@ class Watch(object):
                     and 'metadata' in js['object']
                     and 'resourceVersion' in js['object']['metadata']):
                 self.resource_version = js['object']['metadata']['resourceVersion']
+        elif js['type'].lower() == 'bookmark':
+            self.resource_version = js['object']['metadata']['resourceVersion']
 
         return js
 

--- a/kubernetes_asyncio/watch/watch_test.py
+++ b/kubernetes_asyncio/watch/watch_test.py
@@ -280,3 +280,17 @@ class WatchTest(IsolatedAsyncioTestCase):
 
         fake_resp.release.assert_called_once_with()
         self.assertEqual(watch.resource_version, '10')
+
+    def test_unmarshal_bookmark_succeeds_and_preserves_resource_version(self):
+        w = Watch()
+        event = w.unmarshal_event('{"type": "BOOKMARK", "object": {"apiVersion":'
+                                  '"test.com/v1beta1","kind":"foo","metadata":'
+                                  '{"name": "bar", "resourceVersion": "1"}}}',
+                                  'object')
+        self.assertEqual("BOOKMARK", event['type'])
+
+        # make sure the resource version is preserved,
+        # and the watcher's resource_version is updated
+        self.assertTrue(isinstance(event['object'], dict))
+        self.assertEqual("1", event['object']['metadata']['resourceVersion'])
+        self.assertEqual("1", w.resource_version)


### PR DESCRIPTION
**Issue**: receiving bookmarks in watchers is not handled and raises errors while unmarshalling. 

The official client just returns `type==BOOKMARK` together with the object. 
Even more, they have a todo to set the watcher resource_version attribute in the future; this has been done here as well. 

https://github.com/kubernetes-client/python/blob/36cfbe68a509d9b9d33395b22b6fa94d7d46c30f/kubernetes/base/watch/watch.py#L103

- Test added
- flake & isort applied
