### PR TITLE
fix unittests to work with aiohttp 3.10+111

### DIFF
--- a/kubernetes_asyncio/test/test_admissionregistration_api.py
+++ b/kubernetes_asyncio/test/test_admissionregistration_api.py
@@ -19,10 +19,10 @@ from kubernetes_asyncio.client.api.admissionregistration_api import Admissionreg
 from kubernetes_asyncio.client.rest import ApiException
 
 
-class TestAdmissionregistrationApi(unittest.TestCase):
-    """AdmissionregistrationApi unit test stubs"""
+class TestAdmissionregistrationApi(unittest.IsolatedAsyncioTestCase):
 
-    def setUp(self):
+    """AdmissionregistrationApi unit test stubs"""
+    async def asyncSetUp(self):
         self.api = kubernetes_asyncio.client.api.admissionregistration_api.AdmissionregistrationApi()  # noqa: E501
 
     def tearDown(self):

--- a/kubernetes_asyncio/test/test_admissionregistration_v1_api.py
+++ b/kubernetes_asyncio/test/test_admissionregistration_v1_api.py
@@ -19,10 +19,10 @@ from kubernetes_asyncio.client.api.admissionregistration_v1_api import Admission
 from kubernetes_asyncio.client.rest import ApiException
 
 
-class TestAdmissionregistrationV1Api(unittest.TestCase):
+class TestAdmissionregistrationV1Api(unittest.IsolatedAsyncioTestCase):
     """AdmissionregistrationV1Api unit test stubs"""
 
-    def setUp(self):
+    async def asyncSetUp(self):
         self.api = kubernetes_asyncio.client.api.admissionregistration_v1_api.AdmissionregistrationV1Api()  # noqa: E501
 
     def tearDown(self):

--- a/kubernetes_asyncio/test/test_admissionregistration_v1alpha1_api.py
+++ b/kubernetes_asyncio/test/test_admissionregistration_v1alpha1_api.py
@@ -19,10 +19,10 @@ from kubernetes_asyncio.client.api.admissionregistration_v1alpha1_api import Adm
 from kubernetes_asyncio.client.rest import ApiException
 
 
-class TestAdmissionregistrationV1alpha1Api(unittest.TestCase):
+class TestAdmissionregistrationV1alpha1Api(unittest.IsolatedAsyncioTestCase):
     """AdmissionregistrationV1alpha1Api unit test stubs"""
 
-    def setUp(self):
+    async def asyncSetUp(self):
         self.api = kubernetes_asyncio.client.api.admissionregistration_v1alpha1_api.AdmissionregistrationV1alpha1Api()  # noqa: E501
 
     def tearDown(self):

--- a/kubernetes_asyncio/test/test_admissionregistration_v1beta1_api.py
+++ b/kubernetes_asyncio/test/test_admissionregistration_v1beta1_api.py
@@ -19,10 +19,10 @@ from kubernetes_asyncio.client.api.admissionregistration_v1beta1_api import Admi
 from kubernetes_asyncio.client.rest import ApiException
 
 
-class TestAdmissionregistrationV1beta1Api(unittest.TestCase):
+class TestAdmissionregistrationV1beta1Api(unittest.IsolatedAsyncioTestCase):
     """AdmissionregistrationV1beta1Api unit test stubs"""
 
-    def setUp(self):
+    async def asyncSetUp(self):
         self.api = kubernetes_asyncio.client.api.admissionregistration_v1beta1_api.AdmissionregistrationV1beta1Api()  # noqa: E501
 
     def tearDown(self):

--- a/kubernetes_asyncio/test/test_apiextensions_api.py
+++ b/kubernetes_asyncio/test/test_apiextensions_api.py
@@ -19,10 +19,10 @@ from kubernetes_asyncio.client.api.apiextensions_api import ApiextensionsApi  # 
 from kubernetes_asyncio.client.rest import ApiException
 
 
-class TestApiextensionsApi(unittest.TestCase):
+class TestApiextensionsApi(unittest.IsolatedAsyncioTestCase):
     """ApiextensionsApi unit test stubs"""
 
-    def setUp(self):
+    async def asyncSetUp(self):
         self.api = kubernetes_asyncio.client.api.apiextensions_api.ApiextensionsApi()  # noqa: E501
 
     def tearDown(self):

--- a/kubernetes_asyncio/test/test_apiextensions_v1_api.py
+++ b/kubernetes_asyncio/test/test_apiextensions_v1_api.py
@@ -19,10 +19,10 @@ from kubernetes_asyncio.client.api.apiextensions_v1_api import ApiextensionsV1Ap
 from kubernetes_asyncio.client.rest import ApiException
 
 
-class TestApiextensionsV1Api(unittest.TestCase):
+class TestApiextensionsV1Api(unittest.IsolatedAsyncioTestCase):
     """ApiextensionsV1Api unit test stubs"""
 
-    def setUp(self):
+    async def asyncSetUp(self):
         self.api = kubernetes_asyncio.client.api.apiextensions_v1_api.ApiextensionsV1Api()  # noqa: E501
 
     def tearDown(self):

--- a/kubernetes_asyncio/test/test_apiregistration_api.py
+++ b/kubernetes_asyncio/test/test_apiregistration_api.py
@@ -19,10 +19,10 @@ from kubernetes_asyncio.client.api.apiregistration_api import ApiregistrationApi
 from kubernetes_asyncio.client.rest import ApiException
 
 
-class TestApiregistrationApi(unittest.TestCase):
+class TestApiregistrationApi(unittest.IsolatedAsyncioTestCase):
     """ApiregistrationApi unit test stubs"""
 
-    def setUp(self):
+    async def asyncSetUp(self):
         self.api = kubernetes_asyncio.client.api.apiregistration_api.ApiregistrationApi()  # noqa: E501
 
     def tearDown(self):

--- a/kubernetes_asyncio/test/test_apiregistration_v1_api.py
+++ b/kubernetes_asyncio/test/test_apiregistration_v1_api.py
@@ -19,10 +19,10 @@ from kubernetes_asyncio.client.api.apiregistration_v1_api import Apiregistration
 from kubernetes_asyncio.client.rest import ApiException
 
 
-class TestApiregistrationV1Api(unittest.TestCase):
+class TestApiregistrationV1Api(unittest.IsolatedAsyncioTestCase):
     """ApiregistrationV1Api unit test stubs"""
 
-    def setUp(self):
+    async def asyncSetUp(self):
         self.api = kubernetes_asyncio.client.api.apiregistration_v1_api.ApiregistrationV1Api()  # noqa: E501
 
     def tearDown(self):

--- a/kubernetes_asyncio/test/test_apis_api.py
+++ b/kubernetes_asyncio/test/test_apis_api.py
@@ -19,10 +19,10 @@ from kubernetes_asyncio.client.api.apis_api import ApisApi  # noqa: E501
 from kubernetes_asyncio.client.rest import ApiException
 
 
-class TestApisApi(unittest.TestCase):
+class TestApisApi(unittest.IsolatedAsyncioTestCase):
     """ApisApi unit test stubs"""
 
-    def setUp(self):
+    async def asyncSetUp(self):
         self.api = kubernetes_asyncio.client.api.apis_api.ApisApi()  # noqa: E501
 
     def tearDown(self):

--- a/kubernetes_asyncio/test/test_apps_api.py
+++ b/kubernetes_asyncio/test/test_apps_api.py
@@ -19,10 +19,10 @@ from kubernetes_asyncio.client.api.apps_api import AppsApi  # noqa: E501
 from kubernetes_asyncio.client.rest import ApiException
 
 
-class TestAppsApi(unittest.TestCase):
+class TestAppsApi(unittest.IsolatedAsyncioTestCase):
     """AppsApi unit test stubs"""
 
-    def setUp(self):
+    async def asyncSetUp(self):
         self.api = kubernetes_asyncio.client.api.apps_api.AppsApi()  # noqa: E501
 
     def tearDown(self):

--- a/kubernetes_asyncio/test/test_apps_v1_api.py
+++ b/kubernetes_asyncio/test/test_apps_v1_api.py
@@ -19,10 +19,10 @@ from kubernetes_asyncio.client.api.apps_v1_api import AppsV1Api  # noqa: E501
 from kubernetes_asyncio.client.rest import ApiException
 
 
-class TestAppsV1Api(unittest.TestCase):
+class TestAppsV1Api(unittest.IsolatedAsyncioTestCase):
     """AppsV1Api unit test stubs"""
 
-    def setUp(self):
+    async def asyncSetUp(self):
         self.api = kubernetes_asyncio.client.api.apps_v1_api.AppsV1Api()  # noqa: E501
 
     def tearDown(self):

--- a/kubernetes_asyncio/test/test_authentication_api.py
+++ b/kubernetes_asyncio/test/test_authentication_api.py
@@ -19,10 +19,10 @@ from kubernetes_asyncio.client.api.authentication_api import AuthenticationApi  
 from kubernetes_asyncio.client.rest import ApiException
 
 
-class TestAuthenticationApi(unittest.TestCase):
+class TestAuthenticationApi(unittest.IsolatedAsyncioTestCase):
     """AuthenticationApi unit test stubs"""
 
-    def setUp(self):
+    async def asyncSetUp(self):
         self.api = kubernetes_asyncio.client.api.authentication_api.AuthenticationApi()  # noqa: E501
 
     def tearDown(self):

--- a/kubernetes_asyncio/test/test_authentication_v1_api.py
+++ b/kubernetes_asyncio/test/test_authentication_v1_api.py
@@ -19,10 +19,10 @@ from kubernetes_asyncio.client.api.authentication_v1_api import AuthenticationV1
 from kubernetes_asyncio.client.rest import ApiException
 
 
-class TestAuthenticationV1Api(unittest.TestCase):
+class TestAuthenticationV1Api(unittest.IsolatedAsyncioTestCase):
     """AuthenticationV1Api unit test stubs"""
 
-    def setUp(self):
+    async def asyncSetUp(self):
         self.api = kubernetes_asyncio.client.api.authentication_v1_api.AuthenticationV1Api()  # noqa: E501
 
     def tearDown(self):

--- a/kubernetes_asyncio/test/test_authentication_v1alpha1_api.py
+++ b/kubernetes_asyncio/test/test_authentication_v1alpha1_api.py
@@ -19,10 +19,10 @@ from kubernetes_asyncio.client.api.authentication_v1alpha1_api import Authentica
 from kubernetes_asyncio.client.rest import ApiException
 
 
-class TestAuthenticationV1alpha1Api(unittest.TestCase):
+class TestAuthenticationV1alpha1Api(unittest.IsolatedAsyncioTestCase):
     """AuthenticationV1alpha1Api unit test stubs"""
 
-    def setUp(self):
+    async def asyncSetUp(self):
         self.api = kubernetes_asyncio.client.api.authentication_v1alpha1_api.AuthenticationV1alpha1Api()  # noqa: E501
 
     def tearDown(self):

--- a/kubernetes_asyncio/test/test_authentication_v1beta1_api.py
+++ b/kubernetes_asyncio/test/test_authentication_v1beta1_api.py
@@ -19,10 +19,10 @@ from kubernetes_asyncio.client.api.authentication_v1beta1_api import Authenticat
 from kubernetes_asyncio.client.rest import ApiException
 
 
-class TestAuthenticationV1beta1Api(unittest.TestCase):
+class TestAuthenticationV1beta1Api(unittest.IsolatedAsyncioTestCase):
     """AuthenticationV1beta1Api unit test stubs"""
 
-    def setUp(self):
+    async def asyncSetUp(self):
         self.api = kubernetes_asyncio.client.api.authentication_v1beta1_api.AuthenticationV1beta1Api()  # noqa: E501
 
     def tearDown(self):

--- a/kubernetes_asyncio/test/test_authorization_api.py
+++ b/kubernetes_asyncio/test/test_authorization_api.py
@@ -19,10 +19,10 @@ from kubernetes_asyncio.client.api.authorization_api import AuthorizationApi  # 
 from kubernetes_asyncio.client.rest import ApiException
 
 
-class TestAuthorizationApi(unittest.TestCase):
+class TestAuthorizationApi(unittest.IsolatedAsyncioTestCase):
     """AuthorizationApi unit test stubs"""
 
-    def setUp(self):
+    async def asyncSetUp(self):
         self.api = kubernetes_asyncio.client.api.authorization_api.AuthorizationApi()  # noqa: E501
 
     def tearDown(self):

--- a/kubernetes_asyncio/test/test_authorization_v1_api.py
+++ b/kubernetes_asyncio/test/test_authorization_v1_api.py
@@ -19,10 +19,10 @@ from kubernetes_asyncio.client.api.authorization_v1_api import AuthorizationV1Ap
 from kubernetes_asyncio.client.rest import ApiException
 
 
-class TestAuthorizationV1Api(unittest.TestCase):
+class TestAuthorizationV1Api(unittest.IsolatedAsyncioTestCase):
     """AuthorizationV1Api unit test stubs"""
 
-    def setUp(self):
+    async def asyncSetUp(self):
         self.api = kubernetes_asyncio.client.api.authorization_v1_api.AuthorizationV1Api()  # noqa: E501
 
     def tearDown(self):

--- a/kubernetes_asyncio/test/test_autoscaling_api.py
+++ b/kubernetes_asyncio/test/test_autoscaling_api.py
@@ -19,10 +19,10 @@ from kubernetes_asyncio.client.api.autoscaling_api import AutoscalingApi  # noqa
 from kubernetes_asyncio.client.rest import ApiException
 
 
-class TestAutoscalingApi(unittest.TestCase):
+class TestAutoscalingApi(unittest.IsolatedAsyncioTestCase):
     """AutoscalingApi unit test stubs"""
 
-    def setUp(self):
+    async def asyncSetUp(self):
         self.api = kubernetes_asyncio.client.api.autoscaling_api.AutoscalingApi()  # noqa: E501
 
     def tearDown(self):

--- a/kubernetes_asyncio/test/test_autoscaling_v1_api.py
+++ b/kubernetes_asyncio/test/test_autoscaling_v1_api.py
@@ -19,10 +19,10 @@ from kubernetes_asyncio.client.api.autoscaling_v1_api import AutoscalingV1Api  #
 from kubernetes_asyncio.client.rest import ApiException
 
 
-class TestAutoscalingV1Api(unittest.TestCase):
+class TestAutoscalingV1Api(unittest.IsolatedAsyncioTestCase):
     """AutoscalingV1Api unit test stubs"""
 
-    def setUp(self):
+    async def asyncSetUp(self):
         self.api = kubernetes_asyncio.client.api.autoscaling_v1_api.AutoscalingV1Api()  # noqa: E501
 
     def tearDown(self):

--- a/kubernetes_asyncio/test/test_autoscaling_v2_api.py
+++ b/kubernetes_asyncio/test/test_autoscaling_v2_api.py
@@ -19,10 +19,10 @@ from kubernetes_asyncio.client.api.autoscaling_v2_api import AutoscalingV2Api  #
 from kubernetes_asyncio.client.rest import ApiException
 
 
-class TestAutoscalingV2Api(unittest.TestCase):
+class TestAutoscalingV2Api(unittest.IsolatedAsyncioTestCase):
     """AutoscalingV2Api unit test stubs"""
 
-    def setUp(self):
+    async def asyncSetUp(self):
         self.api = kubernetes_asyncio.client.api.autoscaling_v2_api.AutoscalingV2Api()  # noqa: E501
 
     def tearDown(self):

--- a/kubernetes_asyncio/test/test_batch_api.py
+++ b/kubernetes_asyncio/test/test_batch_api.py
@@ -19,10 +19,10 @@ from kubernetes_asyncio.client.api.batch_api import BatchApi  # noqa: E501
 from kubernetes_asyncio.client.rest import ApiException
 
 
-class TestBatchApi(unittest.TestCase):
+class TestBatchApi(unittest.IsolatedAsyncioTestCase):
     """BatchApi unit test stubs"""
 
-    def setUp(self):
+    async def asyncSetUp(self):
         self.api = kubernetes_asyncio.client.api.batch_api.BatchApi()  # noqa: E501
 
     def tearDown(self):

--- a/kubernetes_asyncio/test/test_batch_v1_api.py
+++ b/kubernetes_asyncio/test/test_batch_v1_api.py
@@ -19,10 +19,10 @@ from kubernetes_asyncio.client.api.batch_v1_api import BatchV1Api  # noqa: E501
 from kubernetes_asyncio.client.rest import ApiException
 
 
-class TestBatchV1Api(unittest.TestCase):
+class TestBatchV1Api(unittest.IsolatedAsyncioTestCase):
     """BatchV1Api unit test stubs"""
 
-    def setUp(self):
+    async def asyncSetUp(self):
         self.api = kubernetes_asyncio.client.api.batch_v1_api.BatchV1Api()  # noqa: E501
 
     def tearDown(self):

--- a/kubernetes_asyncio/test/test_certificates_api.py
+++ b/kubernetes_asyncio/test/test_certificates_api.py
@@ -19,10 +19,10 @@ from kubernetes_asyncio.client.api.certificates_api import CertificatesApi  # no
 from kubernetes_asyncio.client.rest import ApiException
 
 
-class TestCertificatesApi(unittest.TestCase):
+class TestCertificatesApi(unittest.IsolatedAsyncioTestCase):
     """CertificatesApi unit test stubs"""
 
-    def setUp(self):
+    async def asyncSetUp(self):
         self.api = kubernetes_asyncio.client.api.certificates_api.CertificatesApi()  # noqa: E501
 
     def tearDown(self):

--- a/kubernetes_asyncio/test/test_certificates_v1_api.py
+++ b/kubernetes_asyncio/test/test_certificates_v1_api.py
@@ -19,10 +19,10 @@ from kubernetes_asyncio.client.api.certificates_v1_api import CertificatesV1Api 
 from kubernetes_asyncio.client.rest import ApiException
 
 
-class TestCertificatesV1Api(unittest.TestCase):
+class TestCertificatesV1Api(unittest.IsolatedAsyncioTestCase):
     """CertificatesV1Api unit test stubs"""
 
-    def setUp(self):
+    async def asyncSetUp(self):
         self.api = kubernetes_asyncio.client.api.certificates_v1_api.CertificatesV1Api()  # noqa: E501
 
     def tearDown(self):

--- a/kubernetes_asyncio/test/test_certificates_v1alpha1_api.py
+++ b/kubernetes_asyncio/test/test_certificates_v1alpha1_api.py
@@ -19,10 +19,10 @@ from kubernetes_asyncio.client.api.certificates_v1alpha1_api import Certificates
 from kubernetes_asyncio.client.rest import ApiException
 
 
-class TestCertificatesV1alpha1Api(unittest.TestCase):
+class TestCertificatesV1alpha1Api(unittest.IsolatedAsyncioTestCase):
     """CertificatesV1alpha1Api unit test stubs"""
 
-    def setUp(self):
+    async def asyncSetUp(self):
         self.api = kubernetes_asyncio.client.api.certificates_v1alpha1_api.CertificatesV1alpha1Api()  # noqa: E501
 
     def tearDown(self):

--- a/kubernetes_asyncio/test/test_coordination_api.py
+++ b/kubernetes_asyncio/test/test_coordination_api.py
@@ -19,10 +19,10 @@ from kubernetes_asyncio.client.api.coordination_api import CoordinationApi  # no
 from kubernetes_asyncio.client.rest import ApiException
 
 
-class TestCoordinationApi(unittest.TestCase):
+class TestCoordinationApi(unittest.IsolatedAsyncioTestCase):
     """CoordinationApi unit test stubs"""
 
-    def setUp(self):
+    async def asyncSetUp(self):
         self.api = kubernetes_asyncio.client.api.coordination_api.CoordinationApi()  # noqa: E501
 
     def tearDown(self):

--- a/kubernetes_asyncio/test/test_coordination_v1_api.py
+++ b/kubernetes_asyncio/test/test_coordination_v1_api.py
@@ -19,10 +19,10 @@ from kubernetes_asyncio.client.api.coordination_v1_api import CoordinationV1Api 
 from kubernetes_asyncio.client.rest import ApiException
 
 
-class TestCoordinationV1Api(unittest.TestCase):
+class TestCoordinationV1Api(unittest.IsolatedAsyncioTestCase):
     """CoordinationV1Api unit test stubs"""
 
-    def setUp(self):
+    async def asyncSetUp(self):
         self.api = kubernetes_asyncio.client.api.coordination_v1_api.CoordinationV1Api()  # noqa: E501
 
     def tearDown(self):

--- a/kubernetes_asyncio/test/test_core_api.py
+++ b/kubernetes_asyncio/test/test_core_api.py
@@ -19,10 +19,10 @@ from kubernetes_asyncio.client.api.core_api import CoreApi  # noqa: E501
 from kubernetes_asyncio.client.rest import ApiException
 
 
-class TestCoreApi(unittest.TestCase):
+class TestCoreApi(unittest.IsolatedAsyncioTestCase):
     """CoreApi unit test stubs"""
 
-    def setUp(self):
+    async def asyncSetUp(self):
         self.api = kubernetes_asyncio.client.api.core_api.CoreApi()  # noqa: E501
 
     def tearDown(self):

--- a/kubernetes_asyncio/test/test_core_v1_api.py
+++ b/kubernetes_asyncio/test/test_core_v1_api.py
@@ -19,10 +19,10 @@ from kubernetes_asyncio.client.api.core_v1_api import CoreV1Api  # noqa: E501
 from kubernetes_asyncio.client.rest import ApiException
 
 
-class TestCoreV1Api(unittest.TestCase):
+class TestCoreV1Api(unittest.IsolatedAsyncioTestCase):
     """CoreV1Api unit test stubs"""
 
-    def setUp(self):
+    async def asyncSetUp(self):
         self.api = kubernetes_asyncio.client.api.core_v1_api.CoreV1Api()  # noqa: E501
 
     def tearDown(self):

--- a/kubernetes_asyncio/test/test_custom_objects_api.py
+++ b/kubernetes_asyncio/test/test_custom_objects_api.py
@@ -19,10 +19,10 @@ from kubernetes_asyncio.client.api.custom_objects_api import CustomObjectsApi  #
 from kubernetes_asyncio.client.rest import ApiException
 
 
-class TestCustomObjectsApi(unittest.TestCase):
+class TestCustomObjectsApi(unittest.IsolatedAsyncioTestCase):
     """CustomObjectsApi unit test stubs"""
 
-    def setUp(self):
+    async def asyncSetUp(self):
         self.api = kubernetes_asyncio.client.api.custom_objects_api.CustomObjectsApi()  # noqa: E501
 
     def tearDown(self):

--- a/kubernetes_asyncio/test/test_discovery_api.py
+++ b/kubernetes_asyncio/test/test_discovery_api.py
@@ -19,10 +19,10 @@ from kubernetes_asyncio.client.api.discovery_api import DiscoveryApi  # noqa: E5
 from kubernetes_asyncio.client.rest import ApiException
 
 
-class TestDiscoveryApi(unittest.TestCase):
+class TestDiscoveryApi(unittest.IsolatedAsyncioTestCase):
     """DiscoveryApi unit test stubs"""
 
-    def setUp(self):
+    async def asyncSetUp(self):
         self.api = kubernetes_asyncio.client.api.discovery_api.DiscoveryApi()  # noqa: E501
 
     def tearDown(self):

--- a/kubernetes_asyncio/test/test_discovery_v1_api.py
+++ b/kubernetes_asyncio/test/test_discovery_v1_api.py
@@ -19,10 +19,10 @@ from kubernetes_asyncio.client.api.discovery_v1_api import DiscoveryV1Api  # noq
 from kubernetes_asyncio.client.rest import ApiException
 
 
-class TestDiscoveryV1Api(unittest.TestCase):
+class TestDiscoveryV1Api(unittest.IsolatedAsyncioTestCase):
     """DiscoveryV1Api unit test stubs"""
 
-    def setUp(self):
+    async def asyncSetUp(self):
         self.api = kubernetes_asyncio.client.api.discovery_v1_api.DiscoveryV1Api()  # noqa: E501
 
     def tearDown(self):

--- a/kubernetes_asyncio/test/test_events_api.py
+++ b/kubernetes_asyncio/test/test_events_api.py
@@ -19,10 +19,10 @@ from kubernetes_asyncio.client.api.events_api import EventsApi  # noqa: E501
 from kubernetes_asyncio.client.rest import ApiException
 
 
-class TestEventsApi(unittest.TestCase):
+class TestEventsApi(unittest.IsolatedAsyncioTestCase):
     """EventsApi unit test stubs"""
 
-    def setUp(self):
+    async def asyncSetUp(self):
         self.api = kubernetes_asyncio.client.api.events_api.EventsApi()  # noqa: E501
 
     def tearDown(self):

--- a/kubernetes_asyncio/test/test_events_v1_api.py
+++ b/kubernetes_asyncio/test/test_events_v1_api.py
@@ -19,10 +19,10 @@ from kubernetes_asyncio.client.api.events_v1_api import EventsV1Api  # noqa: E50
 from kubernetes_asyncio.client.rest import ApiException
 
 
-class TestEventsV1Api(unittest.TestCase):
+class TestEventsV1Api(unittest.IsolatedAsyncioTestCase):
     """EventsV1Api unit test stubs"""
 
-    def setUp(self):
+    async def asyncSetUp(self):
         self.api = kubernetes_asyncio.client.api.events_v1_api.EventsV1Api()  # noqa: E501
 
     def tearDown(self):

--- a/kubernetes_asyncio/test/test_flowcontrol_apiserver_api.py
+++ b/kubernetes_asyncio/test/test_flowcontrol_apiserver_api.py
@@ -19,10 +19,10 @@ from kubernetes_asyncio.client.api.flowcontrol_apiserver_api import FlowcontrolA
 from kubernetes_asyncio.client.rest import ApiException
 
 
-class TestFlowcontrolApiserverApi(unittest.TestCase):
+class TestFlowcontrolApiserverApi(unittest.IsolatedAsyncioTestCase):
     """FlowcontrolApiserverApi unit test stubs"""
 
-    def setUp(self):
+    async def asyncSetUp(self):
         self.api = kubernetes_asyncio.client.api.flowcontrol_apiserver_api.FlowcontrolApiserverApi()  # noqa: E501
 
     def tearDown(self):

--- a/kubernetes_asyncio/test/test_flowcontrol_apiserver_v1_api.py
+++ b/kubernetes_asyncio/test/test_flowcontrol_apiserver_v1_api.py
@@ -19,10 +19,10 @@ from kubernetes_asyncio.client.api.flowcontrol_apiserver_v1_api import Flowcontr
 from kubernetes_asyncio.client.rest import ApiException
 
 
-class TestFlowcontrolApiserverV1Api(unittest.TestCase):
+class TestFlowcontrolApiserverV1Api(unittest.IsolatedAsyncioTestCase):
     """FlowcontrolApiserverV1Api unit test stubs"""
 
-    def setUp(self):
+    async def asyncSetUp(self):
         self.api = kubernetes_asyncio.client.api.flowcontrol_apiserver_v1_api.FlowcontrolApiserverV1Api()  # noqa: E501
 
     def tearDown(self):

--- a/kubernetes_asyncio/test/test_flowcontrol_apiserver_v1beta3_api.py
+++ b/kubernetes_asyncio/test/test_flowcontrol_apiserver_v1beta3_api.py
@@ -19,10 +19,10 @@ from kubernetes_asyncio.client.api.flowcontrol_apiserver_v1beta3_api import Flow
 from kubernetes_asyncio.client.rest import ApiException
 
 
-class TestFlowcontrolApiserverV1beta3Api(unittest.TestCase):
+class TestFlowcontrolApiserverV1beta3Api(unittest.IsolatedAsyncioTestCase):
     """FlowcontrolApiserverV1beta3Api unit test stubs"""
 
-    def setUp(self):
+    async def asyncSetUp(self):
         self.api = kubernetes_asyncio.client.api.flowcontrol_apiserver_v1beta3_api.FlowcontrolApiserverV1beta3Api()  # noqa: E501
 
     def tearDown(self):

--- a/kubernetes_asyncio/test/test_internal_apiserver_api.py
+++ b/kubernetes_asyncio/test/test_internal_apiserver_api.py
@@ -19,10 +19,10 @@ from kubernetes_asyncio.client.api.internal_apiserver_api import InternalApiserv
 from kubernetes_asyncio.client.rest import ApiException
 
 
-class TestInternalApiserverApi(unittest.TestCase):
+class TestInternalApiserverApi(unittest.IsolatedAsyncioTestCase):
     """InternalApiserverApi unit test stubs"""
 
-    def setUp(self):
+    async def asyncSetUp(self):
         self.api = kubernetes_asyncio.client.api.internal_apiserver_api.InternalApiserverApi()  # noqa: E501
 
     def tearDown(self):

--- a/kubernetes_asyncio/test/test_internal_apiserver_v1alpha1_api.py
+++ b/kubernetes_asyncio/test/test_internal_apiserver_v1alpha1_api.py
@@ -19,10 +19,10 @@ from kubernetes_asyncio.client.api.internal_apiserver_v1alpha1_api import Intern
 from kubernetes_asyncio.client.rest import ApiException
 
 
-class TestInternalApiserverV1alpha1Api(unittest.TestCase):
+class TestInternalApiserverV1alpha1Api(unittest.IsolatedAsyncioTestCase):
     """InternalApiserverV1alpha1Api unit test stubs"""
 
-    def setUp(self):
+    async def asyncSetUp(self):
         self.api = kubernetes_asyncio.client.api.internal_apiserver_v1alpha1_api.InternalApiserverV1alpha1Api()  # noqa: E501
 
     def tearDown(self):

--- a/kubernetes_asyncio/test/test_logs_api.py
+++ b/kubernetes_asyncio/test/test_logs_api.py
@@ -19,10 +19,10 @@ from kubernetes_asyncio.client.api.logs_api import LogsApi  # noqa: E501
 from kubernetes_asyncio.client.rest import ApiException
 
 
-class TestLogsApi(unittest.TestCase):
+class TestLogsApi(unittest.IsolatedAsyncioTestCase):
     """LogsApi unit test stubs"""
 
-    def setUp(self):
+    async def asyncSetUp(self):
         self.api = kubernetes_asyncio.client.api.logs_api.LogsApi()  # noqa: E501
 
     def tearDown(self):

--- a/kubernetes_asyncio/test/test_networking_api.py
+++ b/kubernetes_asyncio/test/test_networking_api.py
@@ -19,10 +19,10 @@ from kubernetes_asyncio.client.api.networking_api import NetworkingApi  # noqa: 
 from kubernetes_asyncio.client.rest import ApiException
 
 
-class TestNetworkingApi(unittest.TestCase):
+class TestNetworkingApi(unittest.IsolatedAsyncioTestCase):
     """NetworkingApi unit test stubs"""
 
-    def setUp(self):
+    async def asyncSetUp(self):
         self.api = kubernetes_asyncio.client.api.networking_api.NetworkingApi()  # noqa: E501
 
     def tearDown(self):

--- a/kubernetes_asyncio/test/test_networking_v1_api.py
+++ b/kubernetes_asyncio/test/test_networking_v1_api.py
@@ -19,10 +19,10 @@ from kubernetes_asyncio.client.api.networking_v1_api import NetworkingV1Api  # n
 from kubernetes_asyncio.client.rest import ApiException
 
 
-class TestNetworkingV1Api(unittest.TestCase):
+class TestNetworkingV1Api(unittest.IsolatedAsyncioTestCase):
     """NetworkingV1Api unit test stubs"""
 
-    def setUp(self):
+    async def asyncSetUp(self):
         self.api = kubernetes_asyncio.client.api.networking_v1_api.NetworkingV1Api()  # noqa: E501
 
     def tearDown(self):

--- a/kubernetes_asyncio/test/test_networking_v1alpha1_api.py
+++ b/kubernetes_asyncio/test/test_networking_v1alpha1_api.py
@@ -19,10 +19,10 @@ from kubernetes_asyncio.client.api.networking_v1alpha1_api import NetworkingV1al
 from kubernetes_asyncio.client.rest import ApiException
 
 
-class TestNetworkingV1alpha1Api(unittest.TestCase):
+class TestNetworkingV1alpha1Api(unittest.IsolatedAsyncioTestCase):
     """NetworkingV1alpha1Api unit test stubs"""
 
-    def setUp(self):
+    async def asyncSetUp(self):
         self.api = kubernetes_asyncio.client.api.networking_v1alpha1_api.NetworkingV1alpha1Api()  # noqa: E501
 
     def tearDown(self):

--- a/kubernetes_asyncio/test/test_node_api.py
+++ b/kubernetes_asyncio/test/test_node_api.py
@@ -19,10 +19,10 @@ from kubernetes_asyncio.client.api.node_api import NodeApi  # noqa: E501
 from kubernetes_asyncio.client.rest import ApiException
 
 
-class TestNodeApi(unittest.TestCase):
+class TestNodeApi(unittest.IsolatedAsyncioTestCase):
     """NodeApi unit test stubs"""
 
-    def setUp(self):
+    async def asyncSetUp(self):
         self.api = kubernetes_asyncio.client.api.node_api.NodeApi()  # noqa: E501
 
     def tearDown(self):

--- a/kubernetes_asyncio/test/test_node_v1_api.py
+++ b/kubernetes_asyncio/test/test_node_v1_api.py
@@ -19,10 +19,10 @@ from kubernetes_asyncio.client.api.node_v1_api import NodeV1Api  # noqa: E501
 from kubernetes_asyncio.client.rest import ApiException
 
 
-class TestNodeV1Api(unittest.TestCase):
+class TestNodeV1Api(unittest.IsolatedAsyncioTestCase):
     """NodeV1Api unit test stubs"""
 
-    def setUp(self):
+    async def asyncSetUp(self):
         self.api = kubernetes_asyncio.client.api.node_v1_api.NodeV1Api()  # noqa: E501
 
     def tearDown(self):

--- a/kubernetes_asyncio/test/test_openid_api.py
+++ b/kubernetes_asyncio/test/test_openid_api.py
@@ -19,10 +19,10 @@ from kubernetes_asyncio.client.api.openid_api import OpenidApi  # noqa: E501
 from kubernetes_asyncio.client.rest import ApiException
 
 
-class TestOpenidApi(unittest.TestCase):
+class TestOpenidApi(unittest.IsolatedAsyncioTestCase):
     """OpenidApi unit test stubs"""
 
-    def setUp(self):
+    async def asyncSetUp(self):
         self.api = kubernetes_asyncio.client.api.openid_api.OpenidApi()  # noqa: E501
 
     def tearDown(self):

--- a/kubernetes_asyncio/test/test_policy_api.py
+++ b/kubernetes_asyncio/test/test_policy_api.py
@@ -19,10 +19,10 @@ from kubernetes_asyncio.client.api.policy_api import PolicyApi  # noqa: E501
 from kubernetes_asyncio.client.rest import ApiException
 
 
-class TestPolicyApi(unittest.TestCase):
+class TestPolicyApi(unittest.IsolatedAsyncioTestCase):
     """PolicyApi unit test stubs"""
 
-    def setUp(self):
+    async def asyncSetUp(self):
         self.api = kubernetes_asyncio.client.api.policy_api.PolicyApi()  # noqa: E501
 
     def tearDown(self):

--- a/kubernetes_asyncio/test/test_policy_v1_api.py
+++ b/kubernetes_asyncio/test/test_policy_v1_api.py
@@ -19,10 +19,10 @@ from kubernetes_asyncio.client.api.policy_v1_api import PolicyV1Api  # noqa: E50
 from kubernetes_asyncio.client.rest import ApiException
 
 
-class TestPolicyV1Api(unittest.TestCase):
+class TestPolicyV1Api(unittest.IsolatedAsyncioTestCase):
     """PolicyV1Api unit test stubs"""
 
-    def setUp(self):
+    async def asyncSetUp(self):
         self.api = kubernetes_asyncio.client.api.policy_v1_api.PolicyV1Api()  # noqa: E501
 
     def tearDown(self):

--- a/kubernetes_asyncio/test/test_rbac_authorization_api.py
+++ b/kubernetes_asyncio/test/test_rbac_authorization_api.py
@@ -19,10 +19,10 @@ from kubernetes_asyncio.client.api.rbac_authorization_api import RbacAuthorizati
 from kubernetes_asyncio.client.rest import ApiException
 
 
-class TestRbacAuthorizationApi(unittest.TestCase):
+class TestRbacAuthorizationApi(unittest.IsolatedAsyncioTestCase):
     """RbacAuthorizationApi unit test stubs"""
 
-    def setUp(self):
+    async def asyncSetUp(self):
         self.api = kubernetes_asyncio.client.api.rbac_authorization_api.RbacAuthorizationApi()  # noqa: E501
 
     def tearDown(self):

--- a/kubernetes_asyncio/test/test_rbac_authorization_v1_api.py
+++ b/kubernetes_asyncio/test/test_rbac_authorization_v1_api.py
@@ -19,10 +19,10 @@ from kubernetes_asyncio.client.api.rbac_authorization_v1_api import RbacAuthoriz
 from kubernetes_asyncio.client.rest import ApiException
 
 
-class TestRbacAuthorizationV1Api(unittest.TestCase):
+class TestRbacAuthorizationV1Api(unittest.IsolatedAsyncioTestCase):
     """RbacAuthorizationV1Api unit test stubs"""
 
-    def setUp(self):
+    async def asyncSetUp(self):
         self.api = kubernetes_asyncio.client.api.rbac_authorization_v1_api.RbacAuthorizationV1Api()  # noqa: E501
 
     def tearDown(self):

--- a/kubernetes_asyncio/test/test_resource_api.py
+++ b/kubernetes_asyncio/test/test_resource_api.py
@@ -19,10 +19,10 @@ from kubernetes_asyncio.client.api.resource_api import ResourceApi  # noqa: E501
 from kubernetes_asyncio.client.rest import ApiException
 
 
-class TestResourceApi(unittest.TestCase):
+class TestResourceApi(unittest.IsolatedAsyncioTestCase):
     """ResourceApi unit test stubs"""
 
-    def setUp(self):
+    async def asyncSetUp(self):
         self.api = kubernetes_asyncio.client.api.resource_api.ResourceApi()  # noqa: E501
 
     def tearDown(self):

--- a/kubernetes_asyncio/test/test_resource_v1alpha2_api.py
+++ b/kubernetes_asyncio/test/test_resource_v1alpha2_api.py
@@ -19,10 +19,10 @@ from kubernetes_asyncio.client.api.resource_v1alpha2_api import ResourceV1alpha2
 from kubernetes_asyncio.client.rest import ApiException
 
 
-class TestResourceV1alpha2Api(unittest.TestCase):
+class TestResourceV1alpha2Api(unittest.IsolatedAsyncioTestCase):
     """ResourceV1alpha2Api unit test stubs"""
 
-    def setUp(self):
+    async def asyncSetUp(self):
         self.api = kubernetes_asyncio.client.api.resource_v1alpha2_api.ResourceV1alpha2Api()  # noqa: E501
 
     def tearDown(self):

--- a/kubernetes_asyncio/test/test_scheduling_api.py
+++ b/kubernetes_asyncio/test/test_scheduling_api.py
@@ -19,10 +19,10 @@ from kubernetes_asyncio.client.api.scheduling_api import SchedulingApi  # noqa: 
 from kubernetes_asyncio.client.rest import ApiException
 
 
-class TestSchedulingApi(unittest.TestCase):
+class TestSchedulingApi(unittest.IsolatedAsyncioTestCase):
     """SchedulingApi unit test stubs"""
 
-    def setUp(self):
+    async def asyncSetUp(self):
         self.api = kubernetes_asyncio.client.api.scheduling_api.SchedulingApi()  # noqa: E501
 
     def tearDown(self):

--- a/kubernetes_asyncio/test/test_scheduling_v1_api.py
+++ b/kubernetes_asyncio/test/test_scheduling_v1_api.py
@@ -19,10 +19,10 @@ from kubernetes_asyncio.client.api.scheduling_v1_api import SchedulingV1Api  # n
 from kubernetes_asyncio.client.rest import ApiException
 
 
-class TestSchedulingV1Api(unittest.TestCase):
+class TestSchedulingV1Api(unittest.IsolatedAsyncioTestCase):
     """SchedulingV1Api unit test stubs"""
 
-    def setUp(self):
+    async def asyncSetUp(self):
         self.api = kubernetes_asyncio.client.api.scheduling_v1_api.SchedulingV1Api()  # noqa: E501
 
     def tearDown(self):

--- a/kubernetes_asyncio/test/test_storage_api.py
+++ b/kubernetes_asyncio/test/test_storage_api.py
@@ -19,10 +19,10 @@ from kubernetes_asyncio.client.api.storage_api import StorageApi  # noqa: E501
 from kubernetes_asyncio.client.rest import ApiException
 
 
-class TestStorageApi(unittest.TestCase):
+class TestStorageApi(unittest.IsolatedAsyncioTestCase):
     """StorageApi unit test stubs"""
 
-    def setUp(self):
+    async def asyncSetUp(self):
         self.api = kubernetes_asyncio.client.api.storage_api.StorageApi()  # noqa: E501
 
     def tearDown(self):

--- a/kubernetes_asyncio/test/test_storage_v1_api.py
+++ b/kubernetes_asyncio/test/test_storage_v1_api.py
@@ -19,10 +19,10 @@ from kubernetes_asyncio.client.api.storage_v1_api import StorageV1Api  # noqa: E
 from kubernetes_asyncio.client.rest import ApiException
 
 
-class TestStorageV1Api(unittest.TestCase):
+class TestStorageV1Api(unittest.IsolatedAsyncioTestCase):
     """StorageV1Api unit test stubs"""
 
-    def setUp(self):
+    async def asyncSetUp(self):
         self.api = kubernetes_asyncio.client.api.storage_v1_api.StorageV1Api()  # noqa: E501
 
     def tearDown(self):

--- a/kubernetes_asyncio/test/test_storage_v1alpha1_api.py
+++ b/kubernetes_asyncio/test/test_storage_v1alpha1_api.py
@@ -19,10 +19,10 @@ from kubernetes_asyncio.client.api.storage_v1alpha1_api import StorageV1alpha1Ap
 from kubernetes_asyncio.client.rest import ApiException
 
 
-class TestStorageV1alpha1Api(unittest.TestCase):
+class TestStorageV1alpha1Api(unittest.IsolatedAsyncioTestCase):
     """StorageV1alpha1Api unit test stubs"""
 
-    def setUp(self):
+    async def asyncSetUp(self):
         self.api = kubernetes_asyncio.client.api.storage_v1alpha1_api.StorageV1alpha1Api()  # noqa: E501
 
     def tearDown(self):

--- a/kubernetes_asyncio/test/test_storagemigration_api.py
+++ b/kubernetes_asyncio/test/test_storagemigration_api.py
@@ -19,10 +19,10 @@ from kubernetes_asyncio.client.api.storagemigration_api import StoragemigrationA
 from kubernetes_asyncio.client.rest import ApiException
 
 
-class TestStoragemigrationApi(unittest.TestCase):
+class TestStoragemigrationApi(unittest.IsolatedAsyncioTestCase):
     """StoragemigrationApi unit test stubs"""
 
-    def setUp(self):
+    async def asyncSetUp(self):
         self.api = kubernetes_asyncio.client.api.storagemigration_api.StoragemigrationApi()  # noqa: E501
 
     def tearDown(self):

--- a/kubernetes_asyncio/test/test_storagemigration_v1alpha1_api.py
+++ b/kubernetes_asyncio/test/test_storagemigration_v1alpha1_api.py
@@ -19,10 +19,10 @@ from kubernetes_asyncio.client.api.storagemigration_v1alpha1_api import Storagem
 from kubernetes_asyncio.client.rest import ApiException
 
 
-class TestStoragemigrationV1alpha1Api(unittest.TestCase):
+class TestStoragemigrationV1alpha1Api(unittest.IsolatedAsyncioTestCase):
     """StoragemigrationV1alpha1Api unit test stubs"""
 
-    def setUp(self):
+    async def asyncSetUp(self):
         self.api = kubernetes_asyncio.client.api.storagemigration_v1alpha1_api.StoragemigrationV1alpha1Api()  # noqa: E501
 
     def tearDown(self):

--- a/kubernetes_asyncio/test/test_version_api.py
+++ b/kubernetes_asyncio/test/test_version_api.py
@@ -19,10 +19,10 @@ from kubernetes_asyncio.client.api.version_api import VersionApi  # noqa: E501
 from kubernetes_asyncio.client.rest import ApiException
 
 
-class TestVersionApi(unittest.TestCase):
+class TestVersionApi(unittest.IsolatedAsyncioTestCase):
     """VersionApi unit test stubs"""
 
-    def setUp(self):
+    async def asyncSetUp(self):
         self.api = kubernetes_asyncio.client.api.version_api.VersionApi()  # noqa: E501
 
     def tearDown(self):

--- a/kubernetes_asyncio/test/test_well_known_api.py
+++ b/kubernetes_asyncio/test/test_well_known_api.py
@@ -19,10 +19,10 @@ from kubernetes_asyncio.client.api.well_known_api import WellKnownApi  # noqa: E
 from kubernetes_asyncio.client.rest import ApiException
 
 
-class TestWellKnownApi(unittest.TestCase):
+class TestWellKnownApi(unittest.IsolatedAsyncioTestCase):
     """WellKnownApi unit test stubs"""
 
-    def setUp(self):
+    async def asyncSetUp(self):
         self.api = kubernetes_asyncio.client.api.well_known_api.WellKnownApi()  # noqa: E501
 
     def tearDown(self):

--- a/kubernetes_asyncio/watch/watch_test.py
+++ b/kubernetes_asyncio/watch/watch_test.py
@@ -127,7 +127,7 @@ class WatchTest(IsolatedAsyncioTestCase):
             cnt += 1
         self.assertEqual(cnt, len(side_effects))
 
-    def test_unmarshal_with_float_object(self):
+    async def test_unmarshal_with_float_object(self):
         w = Watch()
         event = w.unmarshal_event('{"type": "ADDED", "object": 1}', 'float')
         self.assertEqual("ADDED", event['type'])
@@ -135,7 +135,7 @@ class WatchTest(IsolatedAsyncioTestCase):
         self.assertTrue(isinstance(event['object'], float))
         self.assertEqual(1, event['raw_object'])
 
-    def test_unmarshal_without_return_type(self):
+    async def test_unmarshal_without_return_type(self):
         w = Watch()
         event = w.unmarshal_event(
             '{"type": "ADDED", "object": ["test1"]}', None)
@@ -143,7 +143,7 @@ class WatchTest(IsolatedAsyncioTestCase):
         self.assertEqual(["test1"], event['object'])
         self.assertEqual(["test1"], event['raw_object'])
 
-    def test_unmarshal_with_empty_return_type(self):
+    async def test_unmarshal_with_empty_return_type(self):
         # empty string as a return_type is a default value
         # if watch can't detect object by function's name
         w = Watch()
@@ -201,7 +201,7 @@ class WatchTest(IsolatedAsyncioTestCase):
                 r'\(401\)\nReason: Unauthorized: Unauthorized'):
             Watch().unmarshal_event(json.dumps(k8s_err), None)
 
-    def test_unmarshal_with_custom_object(self):
+    async def test_unmarshal_with_custom_object(self):
         w = Watch()
         event = w.unmarshal_event('{"type": "ADDED", "object": {"apiVersion":'
                                   '"test.com/v1beta1","kind":"foo","metadata":'
@@ -281,7 +281,7 @@ class WatchTest(IsolatedAsyncioTestCase):
         fake_resp.release.assert_called_once_with()
         self.assertEqual(watch.resource_version, '10')
 
-    def test_unmarshal_bookmark_succeeds_and_preserves_resource_version(self):
+    async def test_unmarshal_bookmark_succeeds_and_preserves_resource_version(self):
         w = Watch()
         event = w.unmarshal_event('{"type": "BOOKMARK", "object": {"apiVersion":'
                                   '"test.com/v1beta1","kind":"foo","metadata":'

--- a/scripts/update-client.sh
+++ b/scripts/update-client.sh
@@ -81,5 +81,8 @@ find "${CLIENT_ROOT}/client/models/" -type f -print0 | xargs -0 sed -i 's/local_
 
 echo ">>> Remove invalid tests (workaround https://github.com/OpenAPITools/openapi-generator/issues/5377)"
 grep -r make_instance "${CLIENT_ROOT}/test/" | awk '{ gsub(":", ""); print $1}' | sort | uniq | xargs rm
+echo ">>> Fix API tests (https://github.com/aio-libs/aiohttp/issues/8555)"
+find "${CLIENT_ROOT}/test/" -type f -print0 | xargs -0 sed -i -e 's/unittest.TestCase/unittest.IsolatedAsyncioTestCase/g' -e 's/def setUp(self):/async def asyncSetUp(self):/g'
+
 
 echo ">>> Done."


### PR DESCRIPTION
This PR adjusts unitests to work with aiohttp 3.10+ where http sessions have to be created within an async function.