### PR TITLE
Added `load_config` function

### DIFF
--- a/kubernetes_asyncio/config/__init__.py
+++ b/kubernetes_asyncio/config/__init__.py
@@ -12,9 +12,35 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from os.path import exists, expanduser
+
 from .config_exception import ConfigException
 from .incluster_config import load_incluster_config
 from .kube_config import (
-    list_kube_config_contexts, load_kube_config, load_kube_config_from_dict,
-    new_client_from_config, new_client_from_config_dict, refresh_token,
+    KUBE_CONFIG_DEFAULT_LOCATION, list_kube_config_contexts, load_kube_config,
+    load_kube_config_from_dict, new_client_from_config,
+    new_client_from_config_dict,
 )
+
+
+async def load_config(**kwargs):
+    """
+    Wrapper function to load the kube_config.
+    It will initially try to load_kube_config from provided path,
+    then check if the KUBE_CONFIG_DEFAULT_LOCATION exists
+    If neither exists, it will fall back to load_incluster_config
+    and inform the user accordingly.
+
+    :param kwargs: A combination of all possible kwargs that
+    can be passed to either load_kube_config or
+    load_incluster_config functions.
+    """
+    if "kube_config_path" in kwargs.keys() or exists(expanduser(KUBE_CONFIG_DEFAULT_LOCATION)):
+        await load_kube_config(**kwargs)
+    else:
+        print(
+            "kube_config_path not provided and "
+            "default location ({0}) does not exist. "
+            "Using inCluster Config. "
+            "This might not work.".format(KUBE_CONFIG_DEFAULT_LOCATION))
+        load_incluster_config(**kwargs)

--- a/kubernetes_asyncio/config/__init__.py
+++ b/kubernetes_asyncio/config/__init__.py
@@ -11,14 +11,17 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import warnings
 from os.path import exists, expanduser
 
 from .config_exception import ConfigException
 from .incluster_config import load_incluster_config
 from .kube_config import (
-    KUBE_CONFIG_DEFAULT_LOCATION, list_kube_config_contexts, load_kube_config,
-    load_kube_config_from_dict, new_client_from_config,
+    KUBE_CONFIG_DEFAULT_LOCATION,
+    list_kube_config_contexts,
+    load_kube_config,
+    load_kube_config_from_dict,
+    new_client_from_config,
     new_client_from_config_dict,
 )
 
@@ -35,12 +38,18 @@ async def load_config(**kwargs):
     can be passed to either load_kube_config or
     load_incluster_config functions.
     """
-    if "kube_config_path" in kwargs.keys() or exists(expanduser(KUBE_CONFIG_DEFAULT_LOCATION)):
+    if "config_file" in kwargs.keys():
+        await load_kube_config(**kwargs)
+    elif "kube_config_path" in kwargs.keys():
+        kwargs["config_file"] = kwargs.pop("kube_config_path", None)
+        await load_kube_config(**kwargs)
+    elif exists(expanduser(KUBE_CONFIG_DEFAULT_LOCATION)):
         await load_kube_config(**kwargs)
     else:
-        print(
+        warnings.warn(
             "kube_config_path not provided and "
             "default location ({0}) does not exist. "
             "Using inCluster Config. "
-            "This might not work.".format(KUBE_CONFIG_DEFAULT_LOCATION))
+            "This might not work.".format(KUBE_CONFIG_DEFAULT_LOCATION)
+        )
         load_incluster_config(**kwargs)

--- a/kubernetes_asyncio/config/__init__.py
+++ b/kubernetes_asyncio/config/__init__.py
@@ -17,11 +17,8 @@ from os.path import exists, expanduser
 from .config_exception import ConfigException
 from .incluster_config import load_incluster_config
 from .kube_config import (
-    KUBE_CONFIG_DEFAULT_LOCATION,
-    list_kube_config_contexts,
-    load_kube_config,
-    load_kube_config_from_dict,
-    new_client_from_config,
+    KUBE_CONFIG_DEFAULT_LOCATION, list_kube_config_contexts, load_kube_config,
+    load_kube_config_from_dict, new_client_from_config,
     new_client_from_config_dict,
 )
 

--- a/kubernetes_asyncio/config/incluster_config.py
+++ b/kubernetes_asyncio/config/incluster_config.py
@@ -114,7 +114,7 @@ class InClusterConfigLoader(object):
             ) + TOKEN_REFRESH_PERIOD
 
 
-def load_incluster_config(client_configuration=None, try_refresh_token=True):
+def load_incluster_config(client_configuration=None, try_refresh_token=True, **kwargs):
     """Use the service account kubernetes gives to pods to connect to kubernetes
     cluster. It's intended for clients that expect to be running inside a pod
     running on kubernetes. It will raise an exception if called from a process
@@ -123,7 +123,6 @@ def load_incluster_config(client_configuration=None, try_refresh_token=True):
     :param client_configuration: The kubernetes.client.Configuration to
     set configs to.
     """
-    InClusterConfigLoader(
-        token_filename=SERVICE_TOKEN_FILENAME,
-        cert_filename=SERVICE_CERT_FILENAME,
-        try_refresh_token=try_refresh_token).load_and_set(client_configuration)
+    kwargs.setdefault("token_filename", SERVICE_TOKEN_FILENAME)
+    kwargs.setdefault("cert_filename", SERVICE_CERT_FILENAME)
+    InClusterConfigLoader(try_refresh_token=try_refresh_token, **kwargs).load_and_set(client_configuration)

--- a/kubernetes_asyncio/config/incluster_config_test.py
+++ b/kubernetes_asyncio/config/incluster_config_test.py
@@ -12,18 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import contextlib
 import datetime
 import os
 import tempfile
 import unittest
 
 from kubernetes_asyncio.client import Configuration
+from kubernetes_asyncio import config
 
 from .config_exception import ConfigException
 from .incluster_config import (
     SERVICE_HOST_ENV_NAME, SERVICE_PORT_ENV_NAME, InClusterConfigLoader,
     _join_host_port,
 )
+from .kube_config_test import FakeConfig
 
 _TEST_TOKEN = "temp_token"
 _TEST_NEW_TOKEN = "temp_new_token"
@@ -40,7 +43,23 @@ _TEST_IPV6_ENVIRON = {SERVICE_HOST_ENV_NAME: _TEST_IPV6_HOST,
                       SERVICE_PORT_ENV_NAME: _TEST_PORT}
 
 
-class InClusterConfigTest(unittest.TestCase):
+@contextlib.contextmanager
+def monkeypatch_kube_config_path():
+    old_kube_config_path = config.KUBE_CONFIG_DEFAULT_LOCATION
+    config.KUBE_CONFIG_DEFAULT_LOCATION = "/path-does-not-exist"
+    yield
+    config.KUBE_CONFIG_DEFAULT_LOCATION = old_kube_config_path
+
+
+@contextlib.contextmanager
+def monkeypatch_environ(new_environ: dict):
+    old_environ = os.environ.copy()
+    os.environ.update(new_environ)
+    yield
+    os.environ = old_environ
+
+
+class InClusterConfigTest(unittest.IsolatedAsyncioTestCase):
 
     def setUp(self):
         self._temp_files = []
@@ -197,6 +216,27 @@ class InClusterConfigTest(unittest.TestCase):
         self.assertEqual("https://" + _TEST_HOST_PORT, client_config.host)
         self.assertEqual(cert_filename, client_config.ssl_ca_cert)
         self.assertEqual("Bearer " + _TEST_TOKEN, client_config.api_key['BearerToken'])
+
+    async def test_load_config_helper(self):
+        token_filename = self._create_file_with_temp_content(_TEST_TOKEN)
+        cert_filename = self._create_file_with_temp_content(_TEST_CERT)
+        expected = FakeConfig(
+            host="https://" + _TEST_HOST_PORT,
+            token="Bearer " + _TEST_TOKEN,
+            ssl_ca_cert=cert_filename,
+        )
+        actual = FakeConfig()
+        with (
+            monkeypatch_kube_config_path(),
+            monkeypatch_environ(_TEST_ENVIRON),
+        ):
+            await config.load_config(
+                client_configuration=actual,
+                try_refresh_token=None,
+                token_filename=token_filename,
+                cert_filename=cert_filename,
+            )
+        self.assertEqual(expected, actual)
 
 
 if __name__ == '__main__':

--- a/kubernetes_asyncio/config/incluster_config_test.py
+++ b/kubernetes_asyncio/config/incluster_config_test.py
@@ -18,8 +18,8 @@ import os
 import tempfile
 import unittest
 
-from kubernetes_asyncio.client import Configuration
 import kubernetes_asyncio.config
+from kubernetes_asyncio.client import Configuration
 
 from .config_exception import ConfigException
 from .incluster_config import (

--- a/kubernetes_asyncio/config/incluster_config_test.py
+++ b/kubernetes_asyncio/config/incluster_config_test.py
@@ -19,7 +19,7 @@ import tempfile
 import unittest
 
 from kubernetes_asyncio.client import Configuration
-from kubernetes_asyncio import config
+import kubernetes_asyncio.config
 
 from .config_exception import ConfigException
 from .incluster_config import (
@@ -45,12 +45,12 @@ _TEST_IPV6_ENVIRON = {SERVICE_HOST_ENV_NAME: _TEST_IPV6_HOST,
 
 @contextlib.contextmanager
 def monkeypatch_kube_config_path():
-    old_kube_config_path = config.KUBE_CONFIG_DEFAULT_LOCATION
-    config.KUBE_CONFIG_DEFAULT_LOCATION = "/path-does-not-exist"
+    old_kube_config_path = kubernetes_asyncio.config.KUBE_CONFIG_DEFAULT_LOCATION
+    kubernetes_asyncio.config.KUBE_CONFIG_DEFAULT_LOCATION = "/path-does-not-exist"
     try:
         yield
     finally:
-        config.KUBE_CONFIG_DEFAULT_LOCATION = old_kube_config_path
+        kubernetes_asyncio.config.KUBE_CONFIG_DEFAULT_LOCATION = old_kube_config_path
 
 
 class InClusterConfigTest(unittest.IsolatedAsyncioTestCase):
@@ -221,7 +221,7 @@ class InClusterConfigTest(unittest.IsolatedAsyncioTestCase):
         )
         actual = FakeConfig()
         with monkeypatch_kube_config_path():
-            await config.load_config(
+            await kubernetes_asyncio.config.load_config(
                 client_configuration=actual,
                 try_refresh_token=None,
                 token_filename=token_filename,

--- a/kubernetes_asyncio/config/kube_config_test.py
+++ b/kubernetes_asyncio/config/kube_config_test.py
@@ -24,6 +24,7 @@ from unittest.mock import Mock, patch
 import yaml
 from six import PY3
 
+from . import load_config
 from .config_exception import ConfigException
 from .kube_config import (
     ENV_KUBECONFIG_PATH_SEPARATOR, ConfigNode, FileOrData, KubeConfigLoader,
@@ -31,7 +32,6 @@ from .kube_config import (
     load_kube_config_from_dict, new_client_from_config,
     new_client_from_config_dict, refresh_token,
 )
-from . import load_config
 
 BEARER_TOKEN_FORMAT = "Bearer %s"
 


### PR DESCRIPTION
Added load config function from https://github.com/kubernetes-client/python/blob/master/kubernetes/base/config/__init__.py#L24. It was pretty much a drop-in copy and paste, aside from having to update the `load_kube_config` call to be `await`ed. I would have copied over any tests as well, but I did not find any. Please let me know if you would like to build some up out or if you'd like me to make any other updates!

Fixes #249 