### PR TITLE
fix rest api aiohttp timeout

### DIFF
--- a/kubernetes_asyncio/client/rest.py
+++ b/kubernetes_asyncio/client/rest.py
@@ -104,7 +104,8 @@ class RESTClientObject(object):
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
-                                 (connection, read) timeouts.
+                                 (connection, read) timeouts or object
+                                 of aiohttp.ClientTimeout.
         """
         method = method.upper()
         assert method in ['GET', 'HEAD', 'DELETE', 'POST', 'PUT',
@@ -127,6 +128,8 @@ class RESTClientObject(object):
                         sock_connect=_request_timeout[0],
                         sock_read=_request_timeout[1],
                 )
+            elif isinstance(_request_timeout, aiohttp.ClientTimeout):
+                timeout = _request_timeout
 
         if 'Content-Type' not in headers:
             headers['Content-Type'] = 'application/json'

--- a/kubernetes_asyncio/client/rest.py
+++ b/kubernetes_asyncio/client/rest.py
@@ -117,7 +117,16 @@ class RESTClientObject(object):
 
         post_params = post_params or {}
         headers = headers or {}
-        timeout = _request_timeout or 5 * 60
+        timeout = aiohttp.ClientTimeout()
+        if _request_timeout:
+            if isinstance(_request_timeout, (int, float)):
+                timeout = aiohttp.ClientTimeout(total=_request_timeout)
+            elif isinstance(_request_timeout, tuple) and len(_request_timeout) == 2:
+                timeout = aiohttp.ClientTimeout(
+                        connect=_request_timeout[0],
+                        sock_connect=_request_timeout[0],
+                        sock_read=_request_timeout[1],
+                )
 
         if 'Content-Type' not in headers:
             headers['Content-Type'] = 'application/json'

--- a/kubernetes_asyncio/client/test_rest.py
+++ b/kubernetes_asyncio/client/test_rest.py
@@ -1,0 +1,31 @@
+import asyncio
+import unittest
+from unittest.mock import AsyncMock
+import aiohttp
+from kubernetes_asyncio.client.rest import RESTClientObject
+from kubernetes_asyncio.client.configuration import Configuration
+class TestRESTClientObject(unittest.IsolatedAsyncioTestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.config = Configuration()
+
+
+    async def test_rest_request_timeout(self):
+        rest_api = RESTClientObject(configuration=self.config)
+        for request_timeout, expected_timeout_arg in [
+                (None, aiohttp.ClientTimeout()),
+                (5.0, aiohttp.ClientTimeout(total=5.0)),
+                (3, aiohttp.ClientTimeout(total=3)),
+                ((5, 7), aiohttp.ClientTimeout(connect=5, sock_connect=5, sock_read=7)),
+        ]:
+            with self.subTest(request_timeout=request_timeout, expected_timeout_arg=expected_timeout_arg):
+                mock_request = AsyncMock()
+                rest_api.pool_manager.request = mock_request
+                await rest_api.request(method="GET", url="http://test-api", _preload_content=False, _request_timeout=request_timeout)
+                mock_request.assert_called_once_with(
+                    method="GET",
+                    url="http://test-api",
+                    timeout=expected_timeout_arg,
+                    headers={"Content-Type": "application/json"}
+                )

--- a/kubernetes_asyncio/client/test_rest.py
+++ b/kubernetes_asyncio/client/test_rest.py
@@ -18,6 +18,7 @@ class TestRESTClientObject(unittest.IsolatedAsyncioTestCase):
                 (5.0, aiohttp.ClientTimeout(total=5.0)),
                 (3, aiohttp.ClientTimeout(total=3)),
                 ((5, 7), aiohttp.ClientTimeout(connect=5, sock_connect=5, sock_read=7)),
+                (aiohttp.ClientTimeout(total=None), aiohttp.ClientTimeout(total=None)),
         ]:
             with self.subTest(request_timeout=request_timeout, expected_timeout_arg=expected_timeout_arg):
                 mock_request = AsyncMock()


### PR DESCRIPTION
Implement timeout behavior same as official python Kubernetes client: https://github.com/kubernetes-client/python/blob/f414832bb05b946eb1758df12f08806b44dd315e/kubernetes/client/rest.py#L146

Following issues will be resolved by this fix:
- https://github.com/tomplus/kubernetes_asyncio/issues/308
- https://github.com/PrefectHQ/prefect/issues/15259
- https://github.com/PrefectHQ/prefect/issues/14954

