### PR TITLE
allow resource names >2 parts

### DIFF
--- a/kubernetes_asyncio/dynamic/discovery.py
+++ b/kubernetes_asyncio/dynamic/discovery.py
@@ -189,7 +189,8 @@ class Discoverer(object):
         resources_raw = list(filter(lambda r: '/' not in r['name'], resources_response))
         subresources_raw = list(filter(lambda r: '/' in r['name'], resources_response))
         for subresource in subresources_raw:
-            resource, name = subresource['name'].split('/')
+            # Handle resources with >2 parts in their name
+            resource, name = subresource['name'].split('/', 1)
             if not subresources.get(resource):
                 subresources[resource] = {}
             subresources[resource][name] = subresource


### PR DESCRIPTION
Dynamic client discovery for resources with three part names, the processing fails. Allow for processing names with >2 parts.

This was failing on an OpenShift environment with the resource 'virtualmachineinstances/sev/fetchcertchain'

#342 