### PR TITLE
Fallback to merge patch

### DIFF
--- a/examples/patch.py
+++ b/examples/patch.py
@@ -99,7 +99,8 @@ async def main():
             SERVICE_NAME,
             SERVICE_NS,
             patch,
-            _content_type="application/merge-patch+json",  # required to force merge patch
+            # required to force merge patch when strategic merge patch would otherwise be used
+            _content_type="application/merge-patch+json",
         )
 
 

--- a/kubernetes_asyncio/client/api_client.py
+++ b/kubernetes_asyncio/client/api_client.py
@@ -539,9 +539,13 @@ class ApiClient(object):
             if ('application/json-patch+json' in content_types and
                     isinstance(body, list)):
                 return 'application/json-patch+json'
-            if ('application/strategic-merge-patch+json' in content_types and
-                    (isinstance(body, dict) or hasattr(body, "to_dict"))):
-                return 'application/strategic-merge-patch+json'
+            if isinstance(body, dict) or hasattr(body, "to_dict"):
+                if 'application/strategic-merge-patch+json' in content_types:
+                    return 'application/strategic-merge-patch+json'
+                elif 'application/merge-patch+json' in content_types:
+                    # Intended for cases where strategic merge patch is not
+                    # supported, like when patching custom objects.
+                    return 'application/merge-patch+json'
 
         if 'application/json' in content_types or '*/*' in content_types:
             return 'application/json'

--- a/scripts/api_client_strategic_merge_patch.diff
+++ b/scripts/api_client_strategic_merge_patch.diff
@@ -1,9 +1,9 @@
---- /tmp/api_client.py	2024-02-25 20:40:28.143350042 +0100
-+++ kubernetes_asyncio/client/api_client.py	2024-02-25 20:40:32.954201652 +0100
-@@ -535,10 +535,13 @@
- 
+--- /tmp/api_client.py	2024-12-18 03:36:59.552742383 +0000
++++ kubernetes_asyncio/client/api_client.py	2024-12-18 03:36:11.062928089 +0000
+@@ -535,10 +535,17 @@
+
          content_types = [x.lower() for x in content_types]
- 
+
 -        if (method == 'PATCH' and
 -                'application/json-patch+json' in content_types and
 -                isinstance(body, list)):
@@ -12,9 +12,13 @@
 +            if ('application/json-patch+json' in content_types and
 +                    isinstance(body, list)):
 +                return 'application/json-patch+json'
-+            if ('application/strategic-merge-patch+json' in content_types and
-+                    (isinstance(body, dict) or hasattr(body, "to_dict"))):
-+                return 'application/strategic-merge-patch+json'
- 
++            if isinstance(body, dict) or hasattr(body, "to_dict"):
++                if 'application/strategic-merge-patch+json' in content_types:
++                    return 'application/strategic-merge-patch+json'
++                elif 'application/merge-patch+json' in content_types:
++                    # Intended for cases where strategic merge patch is not
++                    # supported, like when patching custom objects.
++                    return 'application/merge-patch+json'
+
          if 'application/json' in content_types or '*/*' in content_types:
              return 'application/json'

--- a/scripts/update-client.sh
+++ b/scripts/update-client.sh
@@ -35,7 +35,7 @@ pushd "${CLIENT_ROOT}" > /dev/null
 CLIENT_ROOT=`pwd`
 popd > /dev/null
 
-TEMP_FOLDER=$(mktemp -d) 
+TEMP_FOLDER=$(mktemp -d)
 trap "rm -rf ${TEMP_FOLDER}" EXIT SIGINT
 
 SETTING_FILE="${TEMP_FOLDER}/settings"


### PR DESCRIPTION
Add fallback to merge patch if strategic merge patch is unavailable, as is the case for the custom objects API.