### PR TITLE
Delete extra characters in URL

### DIFF
--- a/kubernetes_asyncio/client/api/custom_objects_api.py
+++ b/kubernetes_asyncio/client/api/custom_objects_api.py
@@ -2971,7 +2971,7 @@ class CustomObjectsApi(object):
         }
 
         return self.api_client.call_api(
-            '/apis/{group}/{version}/{plural}#‎', 'GET',
+            '/apis/{group}/{version}/{plural}', 'GET',
             path_params,
             query_params,
             header_params,


### PR DESCRIPTION
Fixes #353 

After about an hour of debugging I noticed that some characters were typed incorrectly in the URL of the method `list_custom_object_for_all_namespaces_with_http_info`. I removed them and everything works fine.

![image](https://github.com/user-attachments/assets/d1aa964f-eb7e-43ad-8dbf-47f64386d85d)
