### PR TITLE
Allow for async refresh_api_key_hook methods.

### DIFF
--- a/kubernetes_asyncio/client/api_client.py
+++ b/kubernetes_asyncio/client/api_client.py
@@ -165,7 +165,7 @@ class ApiClient(object):
             post_params.extend(self.files_parameters(files))
 
         # auth setting
-        self.update_params_for_auth(
+        await self.update_params_for_auth(
             header_params, query_params, auth_settings,
             request_auth=_request_auth)
 
@@ -548,7 +548,7 @@ class ApiClient(object):
         else:
             return content_types[0]
 
-    def update_params_for_auth(self, headers, queries, auth_settings,
+    async def update_params_for_auth(self, headers, queries, auth_settings,
                                request_auth=None):
         """Updates header and query params based on authentication setting.
 
@@ -566,7 +566,7 @@ class ApiClient(object):
             return
 
         for auth in auth_settings:
-            auth_setting = self.configuration.auth_settings().get(auth)
+            auth_setting = (await self.configuration.auth_settings()).get(auth)
             if auth_setting:
                 self._apply_auth_params(headers, queries, auth_setting)
 

--- a/kubernetes_asyncio/client/configuration.py
+++ b/kubernetes_asyncio/client/configuration.py
@@ -12,6 +12,7 @@
 
 from __future__ import absolute_import
 
+import asyncio
 import copy
 import logging
 import sys
@@ -370,7 +371,7 @@ conf = client.Configuration(
         self.__logger_format = value
         self.logger_formatter = logging.Formatter(self.__logger_format)
 
-    def get_api_key_with_prefix(self, identifier, alias=None):
+    async def get_api_key_with_prefix(self, identifier, alias=None):
         """Gets API key (with prefix if set).
 
         :param identifier: The identifier of apiKey.
@@ -378,7 +379,9 @@ conf = client.Configuration(
         :return: The token for api key authentication.
         """
         if self.refresh_api_key_hook is not None:
-            self.refresh_api_key_hook(self)
+            result = self.refresh_api_key_hook(self)
+            if asyncio.iscoroutine(result):
+                await result
         key = self.api_key.get(identifier, self.api_key.get(alias) if alias is not None else None)
         if key:
             prefix = self.api_key_prefix.get(identifier)
@@ -402,7 +405,7 @@ conf = client.Configuration(
             basic_auth=username + ':' + password
         ).get('authorization')
 
-    def auth_settings(self):
+    async def auth_settings(self):
         """Gets Auth Settings dict for api client.
 
         :return: The Auth Settings information dict.
@@ -413,7 +416,7 @@ conf = client.Configuration(
                 'type': 'api_key',
                 'in': 'header',
                 'key': 'authorization',
-                'value': self.get_api_key_with_prefix(
+                'value': await self.get_api_key_with_prefix(
                     'BearerToken',
                 ),
             }

--- a/kubernetes_asyncio/config/incluster_config_test.py
+++ b/kubernetes_asyncio/config/incluster_config_test.py
@@ -99,13 +99,13 @@ class InClusterConfigTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(cert_filename, loader.ssl_ca_cert)
         self.assertEqual('Bearer ' + _TEST_TOKEN, loader.token)
 
-    def test_refresh_token(self):
+    async def test_refresh_token(self):
         loader = self.get_test_loader()
         config = Configuration()
         loader.load_and_set(config)
 
         self.assertEqual('Bearer ' + _TEST_TOKEN,
-                         config.get_api_key_with_prefix('BearerToken'))
+                         await config.get_api_key_with_prefix('BearerToken'))
         self.assertEqual('Bearer ' + _TEST_TOKEN, loader.token)
         self.assertIsNotNone(loader.token_expires_at)
 
@@ -113,15 +113,15 @@ class InClusterConfigTest(unittest.IsolatedAsyncioTestCase):
         loader._token_filename = self._create_file_with_temp_content(
             _TEST_NEW_TOKEN)
         self.assertEqual('Bearer ' + _TEST_TOKEN,
-                         config.get_api_key_with_prefix('BearerToken'))
+                         await config.get_api_key_with_prefix('BearerToken'))
 
         loader.token_expires_at = datetime.datetime.now()
         self.assertEqual('Bearer ' + _TEST_NEW_TOKEN,
-                         config.get_api_key_with_prefix('BearerToken'))
+                         await config.get_api_key_with_prefix('BearerToken'))
         self.assertEqual('Bearer ' + _TEST_NEW_TOKEN, loader.token)
         self.assertGreater(loader.token_expires_at, old_token_expires_at)
 
-    def test_refresh_token_default_config_with_copies(self):
+    async def test_refresh_token_default_config_with_copies(self):
         loader = self.get_test_loader()
         loader.load_and_set()
 
@@ -132,7 +132,7 @@ class InClusterConfigTest(unittest.IsolatedAsyncioTestCase):
 
         for config in configs:
             self.assertEqual('Bearer ' + _TEST_TOKEN,
-                             config.get_api_key_with_prefix('BearerToken'))
+                             await config.get_api_key_with_prefix('BearerToken'))
         self.assertEqual('Bearer ' + _TEST_TOKEN, loader.token)
         self.assertIsNotNone(loader.token_expires_at)
 
@@ -142,13 +142,13 @@ class InClusterConfigTest(unittest.IsolatedAsyncioTestCase):
 
         for config in configs:
             self.assertEqual('Bearer ' + _TEST_TOKEN,
-                             config.get_api_key_with_prefix('BearerToken'))
+                             await config.get_api_key_with_prefix('BearerToken'))
 
         loader.token_expires_at = datetime.datetime.now()
 
         for config in configs:
             self.assertEqual('Bearer ' + _TEST_NEW_TOKEN,
-                             config.get_api_key_with_prefix('BearerToken'))
+                             await config.get_api_key_with_prefix('BearerToken'))
 
         self.assertEqual('Bearer ' + _TEST_NEW_TOKEN, loader.token)
         self.assertGreater(loader.token_expires_at, old_token_expires_at)

--- a/scripts/api_client_async_refresh_api_key_hook.diff
+++ b/scripts/api_client_async_refresh_api_key_hook.diff
@@ -1,0 +1,31 @@
+diff --git a/kubernetes_asyncio/client/api_client.py b/kubernetes_asyncio/client/api_client.py
+index 81c12e00..02c9d0f2 100644
+--- a/kubernetes_asyncio/client/api_client.py
++++ b/kubernetes_asyncio/client/api_client.py
+@@ -165,7 +165,7 @@ class ApiClient(object):
+             post_params.extend(self.files_parameters(files))
+
+         # auth setting
+-        self.update_params_for_auth(
++        await self.update_params_for_auth(
+             header_params, query_params, auth_settings,
+             request_auth=_request_auth)
+
+@@ -548,7 +548,7 @@ class ApiClient(object):
+         else:
+             return content_types[0]
+
+-    def update_params_for_auth(self, headers, queries, auth_settings,
++    async def update_params_for_auth(self, headers, queries, auth_settings,
+                                request_auth=None):
+         """Updates header and query params based on authentication setting.
+
+@@ -566,6 +566,6 @@ class ApiClient(object):
+             return
+
+         for auth in auth_settings:
+-            auth_setting = self.configuration.auth_settings().get(auth)
++            auth_setting = (await self.configuration.auth_settings()).get(auth)
+             if auth_setting:
+                 self._apply_auth_params(headers, queries, auth_setting)
+

--- a/scripts/client_configuration_async_refresh_api_key_hook.diff
+++ b/scripts/client_configuration_async_refresh_api_key_hook.diff
@@ -1,0 +1,50 @@
+diff --git a/kubernetes_asyncio/client/configuration.py b/kubernetes_asyncio/client/configuration.py
+index 720bb81f..b2522c23 100644
+--- a/kubernetes_asyncio/client/configuration.py
++++ b/kubernetes_asyncio/client/configuration.py
+@@ -12,6 +12,7 @@
+
+ from __future__ import absolute_import
+
++import asyncio
+ import copy
+ import logging
+ import sys
+@@ -370,7 +371,7 @@ conf = client.Configuration(
+         self.__logger_format = value
+         self.logger_formatter = logging.Formatter(self.__logger_format)
+
+-    def get_api_key_with_prefix(self, identifier, alias=None):
++    async def get_api_key_with_prefix(self, identifier, alias=None):
+         """Gets API key (with prefix if set).
+
+         :param identifier: The identifier of apiKey.
+@@ -378,7 +379,9 @@ conf = client.Configuration(
+         :return: The token for api key authentication.
+         """
+         if self.refresh_api_key_hook is not None:
+-            self.refresh_api_key_hook(self)
++            result = self.refresh_api_key_hook(self)
++            if asyncio.iscoroutine(result):
++                await result
+         key = self.api_key.get(identifier, self.api_key.get(alias) if alias is not None else None)
+         if key:
+             prefix = self.api_key_prefix.get(identifier)
+@@ -402,7 +405,7 @@ conf = client.Configuration(
+             basic_auth=username + ':' + password
+         ).get('authorization')
+
+-    def auth_settings(self):
++    async def auth_settings(self):
+         """Gets Auth Settings dict for api client.
+
+         :return: The Auth Settings information dict.
+@@ -413,7 +416,7 @@ conf = client.Configuration(
+                 'type': 'api_key',
+                 'in': 'header',
+                 'key': 'authorization',
+-                'value': self.get_api_key_with_prefix(
++                'value': await self.get_api_key_with_prefix(
+                     'BearerToken',
+                 ),
+             }

--- a/scripts/update-client.sh
+++ b/scripts/update-client.sh
@@ -83,6 +83,9 @@ echo ">>> don't deep-copy configuration for local_vars_configuration in models"
 patch "${CLIENT_ROOT}/client/configuration.py" "${SCRIPT_ROOT}/client_configuration_get_default_patch.diff"
 find "${CLIENT_ROOT}/client/models/" -type f -print0 | xargs -0 sed -i 's/local_vars_configuration = Configuration.get_default_copy()/local_vars_configuration = Configuration.get_default()/g'
 
+echo ">>> fix generated api client and configuration for async token refreshing..."
+patch "${CLIENT_ROOT}/client/api_client.py" "${SCRIPT_ROOT}/api_client_async_refresh_api_key_hook.diff"
+patch "${CLIENT_ROOT}/client/configuration.py" "${SCRIPT_ROOT}/client_configuration_async_refresh_api_key_hook.diff"
 
 echo ">>> Remove invalid tests (workaround https://github.com/OpenAPITools/openapi-generator/issues/5377)"
 grep -r make_instance "${CLIENT_ROOT}/test/" | awk '{ gsub(":", ""); print $1}' | sort | uniq | xargs rm


### PR DESCRIPTION
Rather than creating an issue, I created this draft pull request to demonstrate what the issue is.

My specific use case is I have implemented the ability to obtain AWS EKS credentials which expire every 15 minutes using an AWS async client. I suspect that more often than not, refreshing credentials will involve i/o and would benefit from async support.