### PR TITLE
Fix usage of response_types_map inside API client's call_api method.

### DIFF
--- a/kubernetes_asyncio/client/api_client.py
+++ b/kubernetes_asyncio/client/api_client.py
@@ -198,7 +198,9 @@ class ApiClient(object):
         if not _preload_content:
             return return_data
 
-        response_type = response_types_map.get(response_data.status, None)
+        response_type = None
+        if response_types_map:
+            response_type = response_types_map.get(response_data.status, None)
 
         if six.PY3 and response_type not in ["file", "bytes"]:
             match = None

--- a/scripts/api_client_response_types_map_patch.diff
+++ b/scripts/api_client_response_types_map_patch.diff
@@ -1,0 +1,15 @@
+diff --git a/kubernetes_asyncio/client/api_client.py b/kubernetes_asyncio/client/api_client.py
+index 0d543478..2791a9cd 100644
+--- a/kubernetes_asyncio/client/api_client.py
++++ b/kubernetes_asyncio/client/api_client.py
+@@ -198,7 +198,9 @@ class ApiClient(object):
+         if not _preload_content:
+             return return_data
+ 
+-        response_type = response_types_map.get(response_data.status, None)
++        response_type = None
++        if response_types_map:
++            response_type = response_types_map.get(response_data.status, None)
+ 
+         if six.PY3 and response_type not in ["file", "bytes"]:
+             match = None

--- a/scripts/update-client.sh
+++ b/scripts/update-client.sh
@@ -66,6 +66,8 @@ sed -i'' "s,^DEVELOPMENT_STATUS = .*,DEVELOPMENT_STATUS = \\\"${DEVELOPMENT_STAT
 
 echo ">>> fix generated api client for patching with strategic merge..."
 patch "${CLIENT_ROOT}/client/api_client.py" "${SCRIPT_ROOT}/api_client_strategic_merge_patch.diff"
+echo ">>> fix generated api client by adding 'none' check..."
+patch "${CLIENT_ROOT}/client/api_client.py" "${SCRIPT_ROOT}/api_client_response_types_map.diff"
 echo ">>> fix generated rest client by increasing aiohttp read buffer to 2MiB..."
 patch "${CLIENT_ROOT}/client/rest.py" "${SCRIPT_ROOT}/rest_client_patch_read_bufsize.diff"
 echo ">>> fix generated rest client and configuration to support customer server hostname TLS verification..."


### PR DESCRIPTION
Fixes https://github.com/tomplus/kubernetes_asyncio/issues/310

I didn't add tests because I couldn't see any existing tests for the call_api method, but if I missed it, please let me know.

(This is a copy of MR #311, but I needed to resolve a conflict and accidentally had been working on the master branch.)