### PR TITLE
fix: handle ContentTypeError in dynamic client discovery

### DIFF
--- a/kubernetes_asyncio/dynamic/discovery.py
+++ b/kubernetes_asyncio/dynamic/discovery.py
@@ -23,6 +23,7 @@ from functools import partial
 from typing import Dict
 
 from urllib3.exceptions import MaxRetryError, ProtocolError
+from aiohttp.client_exceptions import ContentTypeError
 
 from kubernetes_asyncio import __version__
 
@@ -183,7 +184,9 @@ class Discoverer(object):
         try:
             response = await self.client.request('GET', path)
             resources_response = response.resources or []
-        except ServiceUnavailableError:
+        except (ServiceUnavailableError, ContentTypeError):
+            # Handle both service unavailable errors and content type errors
+            # (e.g., when server returns 503 with text/plain)
             resources_response = []
 
         resources_raw = list(filter(lambda r: '/' not in r['name'], resources_response))

--- a/kubernetes_asyncio/dynamic/discovery.py
+++ b/kubernetes_asyncio/dynamic/discovery.py
@@ -25,7 +25,6 @@ from typing import Dict
 from aiohttp.client_exceptions import ContentTypeError
 from urllib3.exceptions import MaxRetryError, ProtocolError
 
-
 from kubernetes_asyncio import __version__
 
 from .exceptions import (

--- a/kubernetes_asyncio/dynamic/discovery.py
+++ b/kubernetes_asyncio/dynamic/discovery.py
@@ -22,8 +22,9 @@ from collections import defaultdict
 from functools import partial
 from typing import Dict
 
-from urllib3.exceptions import MaxRetryError, ProtocolError
 from aiohttp.client_exceptions import ContentTypeError
+from urllib3.exceptions import MaxRetryError, ProtocolError
+
 
 from kubernetes_asyncio import __version__
 


### PR DESCRIPTION
fix: handle ContentTypeError in dynamic client discovery

#367

When the Kubernetes API server returns a 503 Service Unavailable with text/plain 
content type instead of JSON, the dynamic client was failing with a ContentTypeError 
while trying to parse the response. This fix catches ContentTypeError in the 
get_resources_for_api_version method and handles it the same way as ServiceUnavailableError, 
allowing the client to gracefully continue with an empty resources list.

This resolves issues when accessing certain API endpoints that may temporarily 
return non-JSON responses during service unavailability