### PR TITLE
Update supported Python versions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v5
@@ -41,13 +41,13 @@ jobs:
         scripts/kube-init.sh py.test -vvv -s kubernetes_asyncio/e2e_test
 
     - name: Lint with flake8 and isort (only on the latest version of Python)
-      if: matrix.python-version == 3.11
+      if: matrix.python-version == '3.13'
       run: |
         flake8
         isort -c --diff .
 
     - name: Send coverage report
       uses: codecov/codecov-action@v5
-      if: matrix.python-version == 3.11
+      if: matrix.python-version == '3.13'
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ From [PyPi](https://pypi.python.org/pypi/kubernetes_asyncio/) directly:
 pip install kubernetes_asyncio
 ```
 
-It requires Python 3.6+
+It requires Python 3.10+
 
 ## Example
 

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ setup(
         "OpenAPI",
         "Kubernetes"],
     install_requires=REQUIRES,
+    python_requires=">=3.10",
     tests_require=TESTS_REQUIRES,
     packages=[
         'kubernetes_asyncio',
@@ -73,12 +74,9 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
     ],
 )


### PR DESCRIPTION
Heya 👋🏼

I noticed that the supported Python version in the README.md doesn't
match the reality in test config, so I updated the supported list to
currently maintained Python versions.

See the list here: https://endoflife.date/python

I also noticed that the general tooling is also a bit outdated; the
various setup.py, setup.cfg, MANIFEST.in, requirements.txt etc which can
all be replaced with a pyproject.toml + something like uv/poetry.

If there is general appetite from the maintainers, happy to send some
follow up PRs to make this a bit better.
