### PR TITLE
feat(config): support cluster proxy-url from kubeconfig

### DIFF
--- a/kubernetes_asyncio/config/kube_config.py
+++ b/kubernetes_asyncio/config/kube_config.py
@@ -396,6 +396,8 @@ class KubeConfigLoader(object):
             self.verify_ssl = not self._cluster['insecure-skip-tls-verify']
         if 'tls-server-name' in self._cluster:
             self.tls_server_name = self._cluster['tls-server-name']
+        if 'proxy-url' in self._cluster:
+            self.proxy = self._cluster['proxy-url']
 
     def _set_config(self, client_configuration):
 
@@ -403,7 +405,8 @@ class KubeConfigLoader(object):
             client_configuration.api_key['BearerToken'] = self.token
 
         # copy these keys directly from self to configuration object
-        keys = ['host', 'ssl_ca_cert', 'cert_file', 'key_file', 'verify_ssl', 'tls_server_name']
+        keys = ['host', 'ssl_ca_cert', 'cert_file', 'key_file',
+                'verify_ssl', 'tls_server_name', 'proxy']
         for key in keys:
             if key in self.__dict__:
                 setattr(client_configuration, key, getattr(self, key))


### PR DESCRIPTION
Closes: https://github.com/tomplus/kubernetes_asyncio/issues/377

### What this PR does

Adds support for the `proxy-url` field in kubeconfig cluster definitions.
When present, the value is read by `KubeConfigLoader` and propagated to
the client `Configuration`, allowing the underlying aiohttp transport
to route requests through the configured proxy.

This brings kubernetes-asyncio behavior in line with kubectl and
client-go, which already honor `proxy-url`.

### How it works

- `KubeConfigLoader._load_cluster_info` reads `proxy-url` from the
  cluster definition.
- The value is stored on the loader and copied into
  `client.Configuration.proxy`.
- `RESTClientObject` passes the proxy value to aiohttp, which performs
  HTTP CONNECT tunneling for HTTPS requests.

---

### Tests

- Added unit test verifying `proxy-url` is loaded from kubeconfig and
  propagated to `Configuration.proxy`.
- Added client-level test ensuring a new ApiClient created from
  kubeconfig includes the proxy configuration.

---

### Manual verification

- Started a local HTTP proxy (mitmproxy) on `127.0.0.1:8899`.
- Created a kubeconfig with a cluster-level `proxy-url`.
- Built an ApiClient via `new_client_from_config`.
- Verified `Configuration.proxy` is populated.
- Observed HTTPS requests reaching the proxy (CONNECT tunnel).
- Removed `proxy-url` and confirmed no proxy traffic.
<img width="1067" height="386" alt="Screenshot 2025-12-22 142451" src="https://github.com/user-attachments/assets/0662e3de-8199-4cba-9bb8-f4d43f471a20" />

<img width="646" height="375" alt="Screenshot 2025-12-22 142035" src="https://github.com/user-attachments/assets/892c6685-5705-47b9-b720-f3098eb2afd4" />


