### PR TITLE
Fix: HTTP status check skipped when _preload_content=False in REST client

### DIFF
--- a/kubernetes_asyncio/client/rest.py
+++ b/kubernetes_asyncio/client/rest.py
@@ -198,7 +198,7 @@ class RESTClientObject(object):
         if not 200 <= r.status <= 299:
             data = await r.read()
             resp = RESTResponse(r, data)
-            raise ApiException(status=resp.status, reason=resp.reason)
+            raise ApiException(http_resp=resp)
 
         if _preload_content:
 

--- a/kubernetes_asyncio/client/test_rest.py
+++ b/kubernetes_asyncio/client/test_rest.py
@@ -23,6 +23,7 @@ class TestRESTClientObject(unittest.IsolatedAsyncioTestCase):
         ]:
             with self.subTest(request_timeout=request_timeout, expected_timeout_arg=expected_timeout_arg):
                 mock_request = AsyncMock()
+                mock_request.return_value.status = 200
                 rest_api.pool_manager.request = mock_request
                 await rest_api.request(method="GET", url="http://test-api", _preload_content=False, _request_timeout=request_timeout)
                 mock_request.assert_called_once_with(


### PR DESCRIPTION
The `RESTClientObject.request()` method in client/rest.py only checks HTTP status codes when `_preload_content=True`.
Since the dynamic client always passes `_preload_content=False`, error responses (4xx/5xx) are silently returned as successful, bypassing the entire exception handling chain.

```
# rest.py - current code
r = await self.pool_manager.request(**args)
if _preload_content:          # <-- status check is gated behind this
    data = await r.read()
    r = RESTResponse(r, data)
    if not 200 <= r.status <= 299:
        raise ApiException(http_resp=r)
return r
```

The dynamic client (dynamic/client.py) always calls with `_preload_content=False`:

```
# dynamic/client.py, DynamicClient.request()
resp = await self.client.call_api(
    ...
    _preload_content=False,
    ...
)
```

This means `ApiException` is never raised for the dynamic client. The `meta_request` decorator's exception handling (NotFoundError, ConflictError, etc.) is effectively dead code.

Any dynamic client operation against a non-existent resource silently returns the K8s Status error body as a ResourceInstance:
```
client = await k8s_dynamic.DynamicClient(api_client)
resource = await client.resources.get(api_version="karpenter.sh/v1", kind="NodePool")

# This returns a ResourceInstance wrapping the 404 Status body
# instead of raising NotFoundError
result = await resource.get(name="nonexistent-nodepool")

result.to_dict()
# {'kind': 'Status', 'apiVersion': 'v1', 'reason': 'NotFound', 'code': 404, ...}
```

This affects all dynamic client operations: get, delete, patch, create, etc.


This PR moves the status check before the `_preload_content` branch so it runs unconditionally:

```
r = await self.pool_manager.request(**args)

if not 200 <= r.status <= 299:
    data = await r.read()
    resp = RESTResponse(r, data)
    exc = ApiException(status=resp.status, reason=resp.reason)
    exc.body = resp.data
    exc.headers = resp.getheaders()
    raise exc

if _preload_content:
    data = await r.read()
    r = RESTResponse(r, data)
    logger.debug("response body: %s", r.data)

return r
```

- Error responses (4xx/5xx): body is read and included in the ApiException
- Success responses with `_preload_content=False`: returned with body unconsumed, preserving streaming behavior